### PR TITLE
feat: Add initial `netlify.toml` to allow for file-based config builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+  [build]
+    command = "mkdocs build"
+    publish = "site"
+


### PR DESCRIPTION
# Overview

This PR adds an initial [`netlify.toml`](https://app.netlify.com/projects/calypr) file to allow for file-based configuration changes to the deployment builds.

## Current Behavior ⚠️

Currently Netlify previews build for every opened PR ([example](https://deploy-preview-84--calypr.netlify.app/)).

However this is using the free-tier (single member) tier in Netlify, preventing other team members from updating the build config outside of logging into Netlify and updating the values there.

> [!WARNING]
>
> [Netlify Project](https://app.netlify.com/projects/calypr) is currently limited to single user account ⚠️

## New Behavior ✔️

Adding [`netlify.toml`](https://app.netlify.com/projects/calypr) allows for anyomne with write-access to this repo to update and configure the deployment builds!

```toml
  [build]
    command = "mkdocs build"   # <---- Can update build config directly (as opposed to the Netlify UI)!
    publish = "site"
```