### PR TITLE
hotfix: Add CNAME record to preserve custom domain (calypr.org)

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+calypr.org


### PR DESCRIPTION
# Overview

This PR adds a CNAME record (via [`docs/CNAME`](https://github.com/calypr/calypr.github.io/pull/86/changes)) to keep the custom domain set between updates to the `main` branch!

## Current Behavior ⚠️

For every update to main, the GitHub Pages URL is "reset" from https://calypr.org to https://calypr.github.io...

## New Behavior ✔️

> [!TIP]
>
> [MkDocs: Custom Domains](https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains)

GitHub Pages URL is always set to https://calypr.org