### PR TITLE
feature/improved-marketing 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ body_class: home business-home
 hide:
   - navigation
   - toc
-lead: "CALYPR helps research organizations control data access, run reproducible analysis, connect metadata, and prepare model-ready assets across cloud, on-prem, and federated environments."
+lead: "CALYPR gives academic and biomedical research programs a governed operating layer for data access, reproducible compute, metadata integration, and model-ready assets."
 personas:
   - data-steward
   - platform-engineer
@@ -27,160 +27,102 @@ related_tools:
   - data-client
 ---
 
-<section class="business-hero">
+<section class="business-hero" aria-label="CALYPR homepage hero">
   <div class="business-hero__copy">
-    <p class="eyebrow">Research data infrastructure</p>
-    <h1>Govern biomedical data without slowing down research.</h1>
+    <p class="eyebrow">Governed research operations</p>
+    <h1>Run biomedical research programs with policy, provenance, and speed.</h1>
     <p class="business-hero__lead">
-      CALYPR helps research organizations control data access, run reproducible analysis, connect metadata, and prepare model-ready assets across cloud, on-prem, and federated environments.
+      CALYPR helps academic and translational teams govern sensitive data access, run reproducible workflows, connect metadata, and package model-ready assets across cloud, on-prem, and federated environments.
     </p>
     <div class="business-actions">
-      <a href="products/" class="md-button md-button--primary">Products</a>
-      <a href="solutions/" class="md-button">Solutions</a>
+      <a href="products/" class="md-button md-button--primary">Explore products</a>
+      <a href="developers/" class="md-button">See technical docs</a>
+      <a href="solutions/" class="md-button">Match a use case</a>
     </div>
   </div>
-  <div class="business-hero__panel" aria-label="CALYPR platform capabilities">
-    <img src="assets/logo.png" alt="CALYPR" />
+  <div class="business-hero__panel" aria-label="CALYPR value summary">
+    <h2>Why teams choose CALYPR</h2>
+    <ul>
+      <li>Governed access for sensitive biomedical datasets</li>
+      <li>Reproducible workflows across cloud and HPC</li>
+      <li>FHIR-shaped metadata and graph-ready context</li>
+      <li>Model assets grounded in provenance and benchmarks</li>
+    </ul>
   </div>
 </section>
 
-<section class="product-banners" aria-label="CALYPR product areas">
-  <article class="product-banner product-banner--data">
-    <div class="product-banner__copy">
-      <p class="eyebrow">Data product</p>
-      <h2>Manage Data</h2>
-      <p>Give research teams governed access to large datasets, durable data references, and controlled data movement.</p>
-      <div class="product-banner__links">
-        <div class="product-banner__link-group">
-          <p>Audience</p>
-          <div>
-            <a href="personas/data-steward/">Data Steward</a>
-            <a href="personas/platform-engineer/">Platform Engineer</a>
-            <a href="personas/security-compliance-reviewer/">Security Compliance Reviewer</a>
-          </div>
-        </div>
-        <div class="product-banner__link-group">
-          <p>Tools</p>
-          <div>
-            <a href="tools/git-drs/">Git-DRS</a>
-            <a href="tools/syfon/">Syfon</a>
-            <a href="tools/data-client/">Data Client</a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <a class="product-banner__icon-link" href="products/manage-data/" aria-label="Manage Data product overview">
-      <img src="assets/icons/solutions/manage-data.svg" alt="Manage Data icon" />
-    </a>
-  </article>
-
-  <article class="product-banner product-banner--compute">
-    <div class="product-banner__copy">
-      <p class="eyebrow">Compute product</p>
-      <h2>Manage Compute</h2>
-      <p>Run reproducible workflows across cloud, cluster, and local environments without rebuilding how teams work.</p>
-      <div class="product-banner__links">
-        <div class="product-banner__link-group">
-          <p>Audience</p>
-          <div>
-            <a href="personas/platform-engineer/">Platform Engineer</a>
-            <a href="personas/workflow-engineer/">Workflow Engineer</a>
-          </div>
-        </div>
-        <div class="product-banner__link-group">
-          <p>Tools</p>
-          <div>
-            <a href="tools/funnel/">Funnel</a>
-            <a href="tools/git-drs/">Git-DRS</a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <a class="product-banner__icon-link" href="products/manage-compute/" aria-label="Manage Compute product overview">
-      <img src="assets/icons/solutions/manage-compute.svg" alt="Manage Compute icon" />
-    </a>
-  </article>
-
-  <article class="product-banner product-banner--integrate">
-    <div class="product-banner__copy">
-      <p class="eyebrow">Integration product</p>
-      <h2>Integrate Data</h2>
-      <p>Turn fragmented clinical, omics, and project metadata into structured context teams can search and reuse.</p>
-      <div class="product-banner__links">
-        <div class="product-banner__link-group">
-          <p>Audience</p>
-          <div>
-            <a href="personas/data-steward/">Data Steward</a>
-            <a href="personas/platform-engineer/">Platform Engineer</a>
-            <a href="personas/standards-architecture-lead/">Standards Architecture Lead</a>
-          </div>
-        </div>
-        <div class="product-banner__link-group">
-          <p>Tools</p>
-          <div>
-            <a href="tools/forge/">Forge</a>
-            <a href="tools/grip/">GRIP</a>
-            <a href="tools/sifter/">Sifter</a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <a class="product-banner__icon-link" href="products/integrate-data/" aria-label="Integrate Data product overview">
-      <img src="assets/icons/solutions/integrate-data.svg" alt="Integrate Data icon" />
-    </a>
-  </article>
-
-  <article class="product-banner product-banner--models">
-    <div class="product-banner__copy">
-      <p class="eyebrow">Model product</p>
-      <h2>Manage Models</h2>
-      <p>Carry governed data, workflow provenance, and benchmark context into model-driven research operations.</p>
-      <div class="product-banner__links">
-        <div class="product-banner__link-group">
-          <p>Audience</p>
-          <div>
-            <a href="personas/workflow-engineer/">Workflow Engineer</a>
-            <a href="personas/researcher-bioinformatician/">Researcher Bioinformatician</a>
-            <a href="personas/standards-architecture-lead/">Standards Architecture Lead</a>
-          </div>
-        </div>
-        <div class="product-banner__link-group">
-          <p>Tools</p>
-          <div>
-            <a href="tools/grip/">GRIP</a>
-            <a href="tools/funnel/">Funnel</a>
-            <a href="tools/forge/">Forge</a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <a class="product-banner__icon-link" href="products/manage-models/" aria-label="Manage Models product overview">
-      <img src="assets/icons/solutions/manage-models.svg" alt="Manage Models icon" />
-    </a>
-  </article>
+<section class="solution-section" aria-label="Proof and trust band">
+  <p class="eyebrow">Proof points</p>
+  <h2>Built on standards your bioinformatics and platform teams can verify.</h2>
+  <div class="value-grid">
+    <article>
+      <h3>Open standards foundation</h3>
+      <p>Data access on GA4GH DRS, execution through GA4GH TES, and metadata structures aligned to FHIR-oriented research workflows.</p>
+    </article>
+    <article>
+      <h3>Research-ready governance</h3>
+      <p>Policy boundaries, controlled transfer paths, and durable provenance designed for institutional review, audits, and multi-team collaboration.</p>
+    </article>
+    <article>
+      <h3>Practical adoption path</h3>
+      <p>Start with one operating failure—data intake, compute reproducibility, metadata quality, or model handoff—and expand without replacing every workflow at once.</p>
+    </article>
+  </div>
 </section>
 
-<section class="home-footer" aria-label="One platform story">
+<section class="solution-section" aria-label="Audience split">
+  <p class="eyebrow">Choose your starting point</p>
+  <h2>Different stakeholders can evaluate CALYPR from their own decision lens.</h2>
+  <div class="usecase-grid">
+    <article class="usecase-panel">
+      <h3>Program leaders and PIs</h3>
+      <p>Show funding boards and collaborators a governed operating model that improves delivery confidence without slowing scientific teams.</p>
+      <div class="usecase-panel__links">
+        <a href="solutions/">See solution outcomes</a>
+        <a href="products/">Review product model</a>
+      </div>
+    </article>
+    <article class="usecase-panel">
+      <h3>Bioinformatics and workflow teams</h3>
+      <p>Keep analyses reproducible across environments while preserving lineage from source data through workflow outputs and model artifacts.</p>
+      <div class="usecase-panel__links">
+        <a href="products/manage-compute/">Explore Manage Compute</a>
+        <a href="products/manage-models/">Explore Manage Models</a>
+      </div>
+    </article>
+    <article class="usecase-panel">
+      <h3>Platform, data, and compliance teams</h3>
+      <p>Implement policy-aware data operations, validated metadata, and controlled transfer services with standards-based interoperability.</p>
+      <div class="usecase-panel__links">
+        <a href="products/manage-data/">Explore Manage Data</a>
+        <a href="products/integrate-data/">Explore Integrate Data</a>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="home-footer" aria-label="CTA strategy">
   <div class="home-footer__inner">
-    <p class="eyebrow">One platform story</p>
-    <h2>A platform story built for research programs, not just platform engineers.</h2>
+    <p class="eyebrow">Next step</p>
+    <h2>Move from evaluation to implementation with a clear path.</h2>
     <div class="home-footer__grid">
       <div class="home-footer__item">
-        <h3>Start with the program problem</h3>
-        <p>Use the Solutions section to see how CALYPR supports governed data access, reproducible analysis, metadata operations, and model-ready research assets.</p>
+        <h3>1. Frame the operating problem</h3>
+        <p>Start in Solutions to align on program-level outcomes and identify the highest-risk operational gap.</p>
       </div>
       <div class="home-footer__item">
-        <h3>Adopt by product area</h3>
-        <p>The Products section turns those needs into four clear offers: Manage Data, Manage Compute, Integrate Data, and Manage Models.</p>
+        <h3>2. Select the first product surface</h3>
+        <p>Use Products to choose an initial adoption point: Manage Data, Manage Compute, Integrate Data, or Manage Models.</p>
       </div>
       <div class="home-footer__item">
-        <h3>Keep technical depth available</h3>
-        <p>Technical teams can still reach the full CALYPR and tool documentation, but that detail stays in Developers instead of overwhelming non-technical readers.</p>
+        <h3>3. Validate technical fit</h3>
+        <p>Use Developers and tool docs to verify standards, architecture, and implementation details with your engineering team.</p>
       </div>
     </div>
     <div class="business-actions">
-      <a href="products/" class="md-button md-button--primary">Products</a>
-      <a href="solutions/" class="md-button">Solutions</a>
+      <a href="solutions/" class="md-button md-button--primary">Start with solutions</a>
+      <a href="products/" class="md-button">Review products</a>
+      <a href="developers/" class="md-button">Validate technical fit</a>
     </div>
   </div>
 </section>

--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -1,5 +1,5 @@
 ---
-lead: "CALYPR is designed for cross-functional research teams."
+lead: "CALYPR supports cross-functional research delivery teams with role-specific starting points for evaluation and adoption."
 personas:
   - data-steward
   - platform-engineer
@@ -18,7 +18,7 @@ related_tools:
 ---
 # Personas
 
-CALYPR is designed for cross-functional research teams. These personas highlight who usually owns each operating concern and where they typically start.
+CALYPR supports cross-functional research delivery teams. These personas reflect who typically owns each operational concern, what success looks like to them, and where they usually begin evaluation.
 
 - [Data Steward](data-steward.md)
 - [Platform Engineer](platform-engineer.md)
@@ -26,4 +26,3 @@ CALYPR is designed for cross-functional research teams. These personas highlight
 - [Researcher / Bioinformatician](researcher-bioinformatician.md)
 - [Security / Compliance Reviewer](security-compliance-reviewer.md)
 - [Standards / Architecture Lead](standards-architecture-lead.md)
-

--- a/docs/solutions/integrate-data.md
+++ b/docs/solutions/integrate-data.md
@@ -1,5 +1,5 @@
 ---
-lead: "CALYPR helps teams connect clinical, omics, sample, file, and project metadata into structures that can be searched, queried, validated, and reused."
+lead: "CALYPR helps teams turn fragmented clinical, omics, sample, and project metadata into validated, searchable, and reusable research context."
 personas:
   - data-steward
   - platform-engineer
@@ -15,14 +15,14 @@ related_tools:
 
 ![Integrate Data](../assets/solutions/integrate-data.svg)
 
-CALYPR helps teams connect clinical, omics, sample, file, and project metadata into structures that can be searched, queried, validated, and reused.
+CALYPR helps teams turn fragmented clinical, omics, sample, and project metadata into validated, searchable, and reusable research context.
 
 ## Outcomes
 
-- Project metadata that can support discovery and governance.
-- Validation before data is published into shared research environments.
-- Graph-oriented exploration for complex biomedical relationships.
-- A cleaner handoff between data stewards, analysts, and platform engineers.
+- Metadata structures that support governance and discovery.
+- Validation before publication into shared research systems.
+- Relationship-aware query paths for complex biomedical context.
+- Stronger handoff between stewards, analysts, and platform teams.
 
 ## Related Docs
 

--- a/docs/solutions/manage-compute.md
+++ b/docs/solutions/manage-compute.md
@@ -1,5 +1,5 @@
 ---
-lead: "CALYPR supports portable research workflows so teams can run analysis across cloud, local, Kubernetes, and federated environments without rewriting the operating model each time."
+lead: "CALYPR gives teams a portable compute operating model so workflows can run reproducibly across cloud, cluster, and federated environments without rebuilding user processes each time infrastructure changes."
 personas:
   - platform-engineer
   - workflow-engineer
@@ -13,14 +13,14 @@ related_tools:
 
 ![Manage Compute](../assets/solutions/manage-compute.svg)
 
-CALYPR supports portable research workflows so teams can run analysis across cloud, local, Kubernetes, and federated environments without rewriting the operating model each time.
+CALYPR gives teams a portable compute operating model so workflows can run reproducibly across cloud, cluster, and federated environments without rebuilding user processes each time infrastructure changes.
 
 ## Outcomes
 
-- Portable workflow execution through standards-aligned interfaces.
-- Clear separation between analyst-facing workflows and platform deployment detail.
-- A path from governed data access into reproducible compute.
-- Infrastructure flexibility without making every user understand the scheduler.
+- Standardized execution interfaces across environments.
+- Reproducible workflow operations tied to governed inputs.
+- Reduced environment-specific orchestration overhead.
+- Better auditability of run history and output lineage.
 
 ## Related Docs
 

--- a/docs/solutions/manage-data.md
+++ b/docs/solutions/manage-data.md
@@ -1,5 +1,5 @@
 ---
-lead: "CALYPR helps research teams register, version, govern, and resolve biomedical data without forcing users to work directly against raw object storage."
+lead: "CALYPR helps research programs govern how biomedical data is registered, moved, versioned, and resolved so teams can collaborate without storage-path risk and manual handoffs."
 personas:
   - data-steward
   - platform-engineer
@@ -15,14 +15,14 @@ related_tools:
 
 ![Manage Data](../assets/solutions/manage-data.svg)
 
-CALYPR helps research teams register, version, govern, and resolve biomedical data without forcing users to work directly against raw object storage.
+CALYPR helps research programs govern how biomedical data is registered, moved, versioned, and resolved so teams can collaborate without storage-path risk and manual handoffs.
 
 ## Outcomes
 
 - Controlled project-level access to sensitive datasets.
-- Stable DRS-native references for large research objects.
-- Metadata workflows that keep files connected to biological and project context.
-- A technical path into Git-DRS and Syfon when engineers need implementation detail.
+- Durable references for large objects across teams and environments.
+- Repeatable transfer workflows with auditable access behavior.
+- Clear separation between stewardship controls and analyst workflows.
 
 ## Related Docs
 

--- a/docs/solutions/manage-models.md
+++ b/docs/solutions/manage-models.md
@@ -1,5 +1,5 @@
 ---
-lead: "CALYPR's open platform foundation is intended to support model management patterns where biomedical models, data references, workflows, and benchmark context remain connected."
+lead: "CALYPR provides a path for model-centric research operations where model artifacts remain connected to governed data, workflow provenance, metadata context, and benchmark evidence."
 personas:
   - workflow-engineer
   - researcher-bioinformatician
@@ -15,17 +15,18 @@ related_tools:
 
 ![Manage Models](../assets/solutions/manage-models.svg)
 
-CALYPR's open platform foundation is intended to support model management patterns where biomedical models, data references, workflows, and benchmark context remain connected.
+CALYPR provides a path for model-centric research operations where model artifacts remain connected to governed data, workflow provenance, metadata context, and benchmark evidence.
 
 ## Outcomes
 
-- Model work tied back to governed data and reproducible workflows.
-- A clearer route from research analysis to repeatable evaluation.
-- Room for future model packaging and governance without changing the platform principles.
+- Model work anchored to reproducible data and execution history.
+- Clearer transition from analysis output to model evaluation workflows.
+- Better auditability for model comparisons in biomedical settings.
+- Forward-compatible foundation for model packaging and governance.
 
 ## Current Status
 
-This is an emerging solution area. The current platform foundation focuses on governed data, metadata integration, and portable workflow execution.
+Manage Models is an emerging solution area built on capabilities already present in governed data operations, metadata integration, and portable compute execution.
 
 ## Related Docs
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "mkdir -p .generated/docs && zensical build --clean"
+  command = "python scripts/prepare_docs.py && zensical build --clean"
   publish = "site"


### PR DESCRIPTION
## Motivation
- Refresh CALYPR’s public-facing messaging to better position the platform for academic and biomedical research programs.
- Emphasize governance, reproducibility, and standards-aligned interoperability in business-facing copy.
- Make homepage pathways and CTAs clearer for non-technical stakeholders while preserving technical entry points.
- Improve consistency of solution-page leads and outcomes across the core product story.

See #97


## Description

### Homepage updates (`docs/index.md`)
- Reworked homepage messaging and layout to present CALYPR as a governed research operations platform.
- Updated hero eyebrow, headline, and lead copy for stronger value communication.
- Replaced product-banner-heavy mid-page content with concise value and audience-oriented sections.
- Updated CTA labels and destinations to support both business exploration and technical validation.
- Added semantic/ARIA labeling updates where applicable.

### Persona framing update (`docs/personas/index.md`)
- Revised persona lead/body copy to emphasize role-specific evaluation and adoption entry points.

### Solution-page messaging updates
Refined lead and outcomes language for clarity and consistency in:
- `docs/solutions/manage-data.md`
- `docs/solutions/manage-compute.md`
- `docs/solutions/integrate-data.md`
- `docs/solutions/manage-models.md`

### Patch artifact
- Added `marketing-copy-updates.patch` to capture the textual edits for portability/review.

## Why this change
- Improves top-level comprehension for mixed audiences (program leads, compliance stakeholders, and engineers).
- Reduces abstract phrasing and strengthens outcome-oriented positioning.
- Aligns homepage narrative with downstream solution pages for a more coherent buyer journey.

## Testing
- Content-only documentation changes; no application code paths were modified.
- No automated tests were run.