### PR TITLE
fix: Resolve  errors by adding expected files

### DIFF
--- a/docs/javascripts/reveal.js
+++ b/docs/javascripts/reveal.js
@@ -1,0 +1,47 @@
+// Keep header nav active state in sync with instant navigation
+if (typeof document$ !== "undefined") {
+  document$.subscribe(() => {
+    const path = window.location.pathname;
+    document.querySelectorAll(".md-header__nav-item").forEach((item) => {
+      const link = item.querySelector(".md-header__nav-link");
+      if (!link) return;
+      const href = new URL(link.href, location.origin).pathname;
+      const active = href !== "/" && path.startsWith(href);
+      item.classList.toggle("md-header__nav-item--active", active);
+    });
+  });
+}
+
+(() => {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("is-visible");
+          observer.unobserve(entry.target);
+        }
+      }
+    },
+    { threshold: 0, rootMargin: "0px 0px -40px 0px" }
+  );
+
+  const observe = () => {
+    document.querySelectorAll("[data-reveal]").forEach((el) => {
+      const rect = el.getBoundingClientRect();
+      const alreadyVisible = rect.top < window.innerHeight && rect.bottom > 0;
+      if (alreadyVisible) {
+        el.classList.add("is-visible");
+      } else {
+        observer.observe(el);
+      }
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", observe);
+  } else {
+    observe();
+  }
+})();

--- a/docs/termynal.css
+++ b/docs/termynal.css
@@ -1,0 +1,127 @@
+ :root {
+   --color-bg: #252a33;
+   --color-text: #eee;
+   --color-text-subtle: #a2a2a2;
+ }
+
+ [data-termynal] {
+   max-width: 100%;
+   overflow-x: auto;
+   background: var(--color-bg);
+   color: var(--color-text);
+   font-size: 15px;
+   font-family: 'Roboto Mono', 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace;
+   border-radius: 4px;
+   padding: 75px 45px 35px;
+   position: relative;
+   -webkit-box-sizing: border-box;
+   box-sizing: border-box;
+ }
+
+ [data-termynal][data-ty-macos]:before {
+   content: '';
+   position: absolute;
+   top: 15px;
+   left: 15px;
+   display: inline-block;
+   width: 15px;
+   height: 15px;
+   border-radius: 50%;
+   /* A little hack to display the window buttons in one pseudo element. */
+   background: #d9515d;
+   -webkit-box-shadow: 25px 0 0 #f4c025, 50px 0 0 #3ec930;
+   box-shadow: 25px 0 0 #f4c025, 50px 0 0 #3ec930;
+ }
+
+ [data-termynal][data-ty-windows]:before {
+   content: '';
+   position: absolute;
+   top: 15px;
+   left: unset;
+   right: 15px;
+   display: inline-block;
+   width: 15px;
+   height: 15px;
+   /* A little hack to display the window buttons in one pseudo element. */
+   background: #d9515d;
+   -webkit-box-shadow: -25px 0 0 #e6e6e6, -50px 0 0 #e6e6e6;
+   box-shadow: -25px 0 0 #e6e6e6, -50px 0 0 #e6e6e6;
+ }
+
+ [data-termynal]:after {
+   content: 'bash';
+   position: absolute;
+   color: var(--color-text-subtle);
+   top: 5px;
+   left: 0;
+   width: 100%;
+   text-align: center;
+ }
+
+ [data-termynal][data-ty-title]:after {
+   content: attr(data-ty-title);
+ }
+
+ button[data-terminal-control] {
+   float: right;
+   text-align: right;
+   display: block;
+   color: #aebbff;
+   background: none !important;
+   border: none;
+   padding: 0 !important;
+   cursor: pointer;
+ }
+
+ [data-ty] {
+   display: block;
+   line-height: 2;
+   white-space: pre;
+ }
+
+ [data-ty]:before {
+   /* Set up defaults and ensure empty lines are displayed. */
+   content: '';
+   display: inline-block;
+   vertical-align: middle;
+ }
+
+ [data-ty="input"]:before,
+ [data-ty-prompt]:before {
+   margin-right: 0.75em;
+   color: var(--color-text-subtle);
+ }
+
+ [data-ty="input"]:before {
+   content: '$';
+ }
+
+ [data-ty][data-ty-prompt]:before {
+   content: attr(data-ty-prompt);
+ }
+
+ [data-ty-cursor]:after {
+   content: attr(data-ty-cursor);
+   font-family: monospace;
+   margin-left: 0.5em;
+   -webkit-animation: blink 1s infinite;
+   animation: blink 1s infinite;
+ }
+
+ @-webkit-keyframes blink {
+   50% {
+     opacity: 0;
+   }
+ }
+
+ @keyframes blink {
+   50% {
+     opacity: 0;
+   }
+ }
+
+ .termynal-comment {
+   color: #4a968f;
+   font-style: italic;
+   display: block;
+ }

--- a/docs/termynal.js
+++ b/docs/termynal.js
@@ -1,0 +1,262 @@
+'use strict';
+
+class Termynal {
+    /**
+     * Construct the widget's settings.
+     * @param {(string|Node)=} container - Query selector or container element.
+     * @param {Object=} options - Custom settings.
+     * @param {string} options.prefix - Prefix to use for data attributes.
+     * @param {number} options.startDelay - Delay before animation, in ms.
+     * @param {number} options.typeDelay - Delay between each typed character, in ms.
+     * @param {number} options.lineDelay - Delay between each line, in ms.
+     * @param {number} options.progressLength - Number of characters displayed as progress bar.
+     * @param {string} options.progressChar – Character to use for progress bar, defaults to █.
+     * @param {number} options.progressPercent - Max percent of progress.
+     * @param {string} options.cursor – Character to use for cursor, defaults to ▋.
+     * @param {Object[]} lineData - Dynamically loaded line data objects.
+     * @param {boolean} options.noInit - Don't initialise the animation.
+     */
+    constructor(container = '#termynal', options = {}) {
+        this.container = (typeof container === 'string') ? document.querySelector(container) : container;
+        this.pfx = `data-${options.prefix || 'ty'}`;
+        this.originalStartDelay = this.startDelay = options.startDelay
+            || parseFloat(this.container.getAttribute(`${this.pfx}-startDelay`)) || 600;
+        this.originalTypeDelay = this.typeDelay = options.typeDelay
+            || parseFloat(this.container.getAttribute(`${this.pfx}-typeDelay`)) || 90;
+        this.originalLineDelay = this.lineDelay = options.lineDelay
+            || parseFloat(this.container.getAttribute(`${this.pfx}-lineDelay`)) || 1500;
+        this.progressLength = options.progressLength
+            || parseFloat(this.container.getAttribute(`${this.pfx}-progressLength`)) || 40;
+        this.progressChar = options.progressChar
+            || this.container.getAttribute(`${this.pfx}-progressChar`) || '█';
+        this.progressPercent = options.progressPercent
+            || parseFloat(this.container.getAttribute(`${this.pfx}-progressPercent`)) || 100;
+        this.cursor = options.cursor
+            || this.container.getAttribute(`${this.pfx}-cursor`) || '▋';
+        this.lineData = this.lineDataToElements(options.lineData || []);
+        this.loadLines()
+        if (!options.noInit) this.init()
+    }
+
+    loadLines() {
+        // Load all the lines and create the container so that the size is fixed
+        // Otherwise it would be changing and the user viewport would be constantly
+        // moving as she/he scrolls
+        const finish = this.generateFinish()
+        finish.style.visibility = 'hidden'
+        this.container.appendChild(finish)
+        // Appends dynamically loaded lines to existing line elements.
+        this.lines = [...this.container.querySelectorAll(`[${this.pfx}]`)].concat(this.lineData);
+        for (let line of this.lines) {
+            line.style.visibility = 'hidden'
+            this.container.appendChild(line)
+        }
+        const restart = this.generateRestart()
+        restart.style.visibility = 'hidden'
+        this.container.appendChild(restart)
+        this.container.setAttribute('data-termynal', '');
+    }
+
+    /**
+     * Initialise the widget, get lines, clear container and start animation.
+     */
+    init() {
+        /**
+         * Calculates width and height of Termynal container.
+         * If container is empty and lines are dynamically loaded, defaults to browser `auto` or CSS.
+         */
+        const containerStyle = getComputedStyle(this.container);
+        this.container.style.width = containerStyle.width !== '0px' ?
+            containerStyle.width : undefined;
+        this.container.style.minHeight = containerStyle.height !== '0px' ?
+            containerStyle.height : undefined;
+
+        this.container.setAttribute('data-termynal', '');
+        this.container.innerHTML = '';
+        for (let line of this.lines) {
+            line.style.visibility = 'visible'
+        }
+        this.start();
+    }
+
+    /**
+     * Start the animation and rener the lines depending on their data attributes.
+     */
+    async start() {
+        this.addFinish()
+        await this._wait(this.startDelay);
+
+        for (let line of this.lines) {
+            const type = line.getAttribute(this.pfx);
+            const delay = line.getAttribute(`${this.pfx}-delay`) || this.lineDelay;
+
+            if (type == 'input') {
+                line.setAttribute(`${this.pfx}-cursor`, this.cursor);
+                await this.type(line);
+                await this._wait(delay);
+            }
+
+            else if (type == 'progress') {
+                await this.progress(line);
+                await this._wait(delay);
+            }
+
+            else {
+                this.container.appendChild(line);
+                await this._wait(delay);
+            }
+
+            line.removeAttribute(`${this.pfx}-cursor`);
+        }
+        this.addRestart()
+        this.finishElement.style.visibility = 'hidden'
+        this.lineDelay = this.originalLineDelay
+        this.typeDelay = this.originalTypeDelay
+        this.startDelay = this.originalStartDelay
+    }
+
+    generateRestart() {
+        const restart = document.createElement('button')
+        restart.onclick = (e) => {
+            e.preventDefault()
+            this.container.innerHTML = ''
+            this.init()
+        }
+        restart.setAttribute('data-terminal-control', '')
+        restart.innerHTML = "restart ↻"
+        return restart
+    }
+
+    generateFinish() {
+        const finish = document.createElement('button')
+        finish.onclick = (e) => {
+            e.preventDefault()
+            this.lineDelay = 0
+            this.typeDelay = 0
+            this.startDelay = 0
+        }
+        finish.setAttribute('data-terminal-control', '')
+        finish.innerHTML = "fast →"
+        this.finishElement = finish
+        return finish
+    }
+
+    addRestart() {
+        const restart = this.generateRestart()
+        this.container.appendChild(restart)
+    }
+
+    addFinish() {
+        const finish = this.generateFinish()
+        this.container.appendChild(finish)
+    }
+
+    /**
+     * Animate a typed line.
+     * @param {Node} line - The line element to render.
+     */
+    async type(line) {
+        const chars = [...line.textContent];
+        line.textContent = '';
+        this.container.appendChild(line);
+
+        for (let char of chars) {
+            const delay = line.getAttribute(`${this.pfx}-typeDelay`) || this.typeDelay;
+            await this._wait(delay);
+            line.textContent += char;
+        }
+    }
+
+    /**
+     * Animate a progress bar.
+     * @param {Node} line - The line element to render.
+     */
+    async progress(line) {
+        const progressLength = line.getAttribute(`${this.pfx}-progressLength`)
+            || this.progressLength;
+        const progressChar = line.getAttribute(`${this.pfx}-progressChar`)
+            || this.progressChar;
+        const chars = progressChar.repeat(progressLength);
+        const progressPercent = line.getAttribute(`${this.pfx}-progressPercent`)
+            || this.progressPercent;
+        line.textContent = '';
+        this.container.appendChild(line);
+
+        for (let i = 1; i < chars.length + 1; i++) {
+            await this._wait(this.typeDelay);
+            const percent = Math.round(i / chars.length * 100);
+            line.textContent = `${chars.slice(0, i)} ${percent}%`;
+            if (percent > progressPercent) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Helper function for animation delays, called with `await`.
+     * @param {number} time - Timeout, in ms.
+     */
+    _wait(time) {
+        return new Promise(resolve => setTimeout(resolve, time));
+    }
+
+    /**
+     * Converts line data objects into line elements.
+     *
+     * @param {Object[]} lineData - Dynamically loaded lines.
+     * @param {Object} line - Line data object.
+     * @returns {Element[]} - Array of line elements.
+     */
+    lineDataToElements(lineData) {
+        return lineData.map(line => {
+            let div = document.createElement('div');
+            div.innerHTML = `<span ${this._attributes(line)}>${line.value || ''}</span>`;
+
+            return div.firstElementChild;
+        });
+    }
+
+    /**
+     * Helper function for generating attributes string.
+     *
+     * @param {Object} line - Line data object.
+     * @returns {string} - String of attributes.
+     */
+    _attributes(line) {
+        let attrs = '';
+        for (let prop in line) {
+            // Custom add class
+            if (prop === 'class') {
+                attrs += ` class=${line[prop]} `
+                continue
+            }
+            if (prop === 'type') {
+                attrs += `${this.pfx}="${line[prop]}" `
+            } else if (prop !== 'value') {
+                attrs += `${this.pfx}-${prop}="${line[prop]}" `
+            }
+        }
+
+        return attrs;
+    }
+}
+
+/**
+* HTML API: If current script has container(s) specified, initialise Termynal.
+*/
+if (document.currentScript.hasAttribute('data-termynal-container')) {
+    const containers = document.currentScript.getAttribute('data-termynal-container');
+    containers.split('|')
+        .forEach(container => new Termynal(container))
+}
+
+
+(function () {
+    document
+        .querySelectorAll('.termy')
+        .forEach(node => {
+            new Termynal(node, {
+                lineDelay: 500
+            });
+        });
+})()

--- a/docs/tools/funnel/docs/_releases.md
+++ b/docs/tools/funnel/docs/_releases.md
@@ -1,7 +1,7 @@
 | Asset | Download |
 | --- | --- |
-| funnel-darwin-amd64-v0.11.7.tar.gz | [Download](https://github.com/ohsu-comp-bio/funnel/releases/download/v0.11.7/funnel-darwin-amd64-v0.11.7.tar.gz) |
-| funnel-darwin-arm64-v0.11.7.tar.gz | [Download](https://github.com/ohsu-comp-bio/funnel/releases/download/v0.11.7/funnel-darwin-arm64-v0.11.7.tar.gz) |
-| funnel-linux-amd64-v0.11.7.tar.gz | [Download](https://github.com/ohsu-comp-bio/funnel/releases/download/v0.11.7/funnel-linux-amd64-v0.11.7.tar.gz) |
-| funnel-linux-arm64-v0.11.7.tar.gz | [Download](https://github.com/ohsu-comp-bio/funnel/releases/download/v0.11.7/funnel-linux-arm64-v0.11.7.tar.gz) |
-| funnel-v0.11.7-checksums.txt | [Download](https://github.com/ohsu-comp-bio/funnel/releases/download/v0.11.7/funnel-v0.11.7-checksums.txt) |
+| funnel-darwin-amd64-v0.11.12.tar.gz | [Download](https://github.com/calypr/funnel/releases/download/v0.11.12/funnel-darwin-amd64-v0.11.12.tar.gz) |
+| funnel-darwin-arm64-v0.11.12.tar.gz | [Download](https://github.com/calypr/funnel/releases/download/v0.11.12/funnel-darwin-arm64-v0.11.12.tar.gz) |
+| funnel-linux-amd64-v0.11.12.tar.gz | [Download](https://github.com/calypr/funnel/releases/download/v0.11.12/funnel-linux-amd64-v0.11.12.tar.gz) |
+| funnel-linux-arm64-v0.11.12.tar.gz | [Download](https://github.com/calypr/funnel/releases/download/v0.11.12/funnel-linux-arm64-v0.11.12.tar.gz) |
+| funnel-v0.11.12-checksums.txt | [Download](https://github.com/calypr/funnel/releases/download/v0.11.12/funnel-v0.11.12-checksums.txt) |

--- a/docs/tools/funnel/docs/download.md
+++ b/docs/tools/funnel/docs/download.md
@@ -12,23 +12,6 @@ See the [Releases](https://github.com/ohsu-comp-bio/funnel/releases)  page for r
 <!-- Release table -->
 --8<-- "docs/tools/funnel/_releases.md"
 
-## Homebrew
-
-```sh
-brew tap ohsu-comp-bio/formula
-brew install funnel@0.11
-```
-
-## Build the lastest development version
-
-In order to build the latest code, run:
-```shell
-$ git clone https://github.com/ohsu-comp-bio/funnel.git
-$ cd funnel
-$ make
-```
-
-Funnel requires Go 1.21+. Check out the [development docs][dev] for more detail.
-
+Check out the [development docs][dev] for more detail.
 
 [dev]: ./development/developers.md

--- a/docs/tools/git-drs/commands.md
+++ b/docs/tools/git-drs/commands.md
@@ -1,0 +1,488 @@
+# Commands Reference
+
+Complete reference for the `git-drs` CLI as used on the `fix/cli` line.
+
+Git DRS owns Git/DRS orchestration and local metadata. Provider access, signed URL behavior, and cloud inspection are handled through Syfon and client code behind these commands.
+
+> **Navigation:** [Getting Started](getting-started.md) -> **Commands Reference** -> [Troubleshooting](troubleshooting.md)
+
+## Core Setup
+
+### `git drs install`
+
+Install global Git filter configuration for `git-drs`.
+
+```bash
+git drs install
+```
+
+This sets the global `filter.drs.*` entries used by Git clean/smudge/filter operations.
+
+### `git drs init`
+
+Initialize `git-drs` in the current repository.
+
+```bash
+git drs init [flags]
+```
+
+Common flags:
+
+- `--transfers <n>`: concurrent transfers
+- `--upsert`: enable upsert behavior for push/register flows
+- `--multipart-threshold <mb>`: multipart threshold in MB
+- `--enable-data-client-logs`: enable lower-level client logging
+
+Use this when you want to initialize the repo explicitly, or to repair repo-local hooks/config.
+
+For normal onboarding, `git drs remote add ...` now auto-initializes the repository if that setup is missing.
+
+## Remote Configuration
+
+### `git drs remote add gen3 [remote-name] <organization/project>`
+
+Add or refresh a Gen3-backed Syfon remote.
+
+```bash
+git drs remote add gen3 [remote-name] <organization/project> \
+    --cred <credentials-file>
+```
+
+**Options:**
+
+- `--cred <file>`: Path to credentials JSON file (required)
+- `--token <token>`: Token for temporary access (alternative to --cred)
+- `<organization/project>`: Required scope argument, for example `HTAN_INT/BForePC`
+
+**Examples:**
+
+```bash
+# Add production remote
+git drs remote add gen3 production my-program/my-project \
+    --cred /path/to/credentials.json
+
+# Add staging remote
+git drs remote add gen3 staging staging-program/staging-project \
+    --cred /path/to/staging-credentials.json
+```
+
+Notes:
+
+- `remote-name` is optional; if omitted, the default remote name is used.
+- scope is always one positional argument: `organization/project`
+- `--cred` imports a Gen3 credential file
+- `--token` uses a temporary bearer token
+- if the repo has not been initialized yet, this command bootstraps the local `git-drs` hooks/config first
+- bucket resolution is scope-driven; users do not need to provide `--bucket`
+- endpoint resolution comes from the credential/token path; users do not need to provide `--url`
+
+Prerequisite:
+
+- the target `organization/project` must already be mapped to a bucket on the server
+- if no local repo mapping exists, `git-drs` can resolve the visible bucket from the server
+
+### `git drs remote list`
+
+List configured DRS remotes.
+
+```bash
+git drs remote list
+```
+
+### `git drs remote remove <remote-name>`
+
+Remove a configured DRS remote.
+
+```bash
+git drs remote remove <remote-name>
+git drs remote rm <remote-name>
+```
+
+Notes:
+
+- this removes `git-drs` remote config, not normal Git remotes
+- `git remote remove <name>` does not manage `git-drs` remote config
+- if the removed remote was the default and other `git-drs` remotes remain, one remaining remote becomes the new default
+- if the removed remote was the last one, `git-drs` clears the default remote
+
+### `git drs add-url <object-url-or-key> [path]`
+
+Prepare a pointer plus local DRS metadata for an object that already exists in provider storage.
+
+**Usage:**
+
+```bash
+# Preferred: object key resolved against configured bucket scope
+git drs add-url path/to/object.bin data/from-bucket.bin --scheme s3
+
+# Compatibility: explicit provider URL
+git drs add-url s3://my-bucket/path/to/object.bin data/from-bucket.bin
+```
+
+**Options:**
+
+- `--scheme <scheme>`: Required for object-key mode because local bucket mappings persist bucket/prefix, not provider scheme
+- `--sha256 <hex>`: Expected SHA256 checksum when known
+
+**What it does:**
+
+- Resolves the effective org/project bucket scope for the current remote
+- Inspects the provider object through client-owned cloud code
+- Writes a Git LFS pointer into the worktree
+- Stores local DRS metadata for later registration during `git drs push`
+
+### `git drs push [remote-name]`
+
+Push local DRS objects to server. Uploads new files and registers metadata.
+
+**Usage:**
+
+```bash
+# Push to default remote
+git drs push
+
+# Push to specific remote
+git drs push staging
+git drs push production
+```
+
+**What it does:**
+
+- Checks local `.git/drs/lfs/objects/` for DRS metadata
+- For each object, uploads file to bucket if file exists locally
+- If file doesn't exist locally (metadata only), registers metadata without upload
+- Reconciles committed tracked-file deletions against the pushed Git ref delta
+- This enables cross-remote promotion workflows
+
+For tracked data changes, `git drs push` is the normal top-level push command.
+
+**Cross-Remote Promotion:**
+
+Transfer DRS records from one remote to another (eg staging to production) without re-uploading files:
+
+```bash
+# Fetch metadata from staging
+git drs fetch staging
+
+# Push metadata to production (no file upload since files don't exist locally)
+git drs push production
+```
+
+This is useful when files are already in the production bucket with matching SHA256 hashes. It can also be used to reupload files given that the files are pulled to the repo first.
+
+**Note:** `fetch` and `push` are commonly used together. `fetch` pulls metadata from one remote, `push` registers it to another.
+
+### `git drs rm <path>...`
+
+Remove tracked DRS/LFS files from the worktree and index.
+
+**Usage:**
+
+```bash
+git drs rm data/sample.bam
+git drs rm data/sample1.bam data/sample2.bam
+```
+
+**What it does:**
+
+- Validates that each path is tracked as a Git LFS / git-drs file
+- Runs `git rm` for those paths
+- Does not mutate remote DRS state immediately
+
+**Remote behavior on push:**
+
+When the deletion is committed and pushed:
+
+- `git drs push` and the managed `pre-push` hook derive deleted pointers from the pushed Git commit delta
+- if the scoped record has exactly one `controlled_access` entry, the whole DRS record is deleted
+- if the scoped record has multiple `controlled_access` entries, only the current `organization/project` resource is removed
+- underlying object bytes are not deleted by default
+
+### `git drs copy-records [source-remote] <target-remote> <organization/project>`
+
+Copy Syfon records for one `organization/project` scope from one configured remote to another.
+
+**Usage:**
+
+```bash
+git drs copy-records \
+  <source-remote> \
+  <target-remote> \
+  <organization/project>
+```
+
+Or, to copy from the configured default remote:
+
+```bash
+git drs copy-records \
+  <target-remote> \
+  <organization/project>
+```
+
+**Options:**
+
+- `<source-remote>`: Source remote. Optional. Defaults to the configured default remote.
+- `<target-remote>`: Target remote. Required.
+- `<organization/project>`: Required scope argument, for example `HTAN_INT/BForePC`.
+- `--batch-size <n>`: Source page size and target bulk write size. Default: `250`.
+
+**What it does:**
+
+- Reads all source records for the requested `organization/project` using Syfon's internal bulk/list APIs
+- Looks up matching DIDs on the target in batches
+- Creates records that do not already exist on the target
+- For existing DIDs, preserves the target record and only merges:
+  - `controlled_access`
+  - `access_methods`
+
+**Merge semantics for existing target records:**
+
+- Existing target metadata is preserved
+- `controlled_access` becomes the union of source and target values
+- `access_methods` becomes the union of source and target values
+- Records with no effective change are skipped
+
+**Example:**
+
+```bash
+git drs copy-records \
+  dev \
+  prod \
+  HTAN_INT/BForePC
+```
+
+**When to use it:**
+
+- Promote DRS metadata between Syfon instances
+- Backfill `controlled_access` and `access_methods` onto an existing target instance
+- Copy project-scoped records without re-uploading object bytes
+
+### `git drs query`
+
+Query a DRS object by its DRS ID or SHA256 checksum.
+
+**Usage:**
+
+```bash
+# Query by DRS ID (default behavior)
+git drs query <drs-id>
+
+# Query by SHA256 checksum
+git drs query --checksum <sha256>
+```
+
+## Bucket Mapping
+
+These commands are typically steward/admin setup, not day-to-day end-user commands.
+
+### `git drs bucket add`
+
+Declare bucket credentials for a remote.
+
+### `git drs bucket add-organization`
+
+Map an organization to a bucket path.
+
+```bash
+git drs bucket add-organization production \
+  --organization HTAN_INT \
+  --path s3://cbds/htan-int
+```
+
+### `git drs bucket add-project`
+
+```bash
+# Known SHA path
+git drs add-url s3://bucket/path/file.bin data/file.bin --sha256 <sha256>
+
+# Unknown SHA path
+git drs add-url s3://bucket/path/file.bin data/file.bin
+```
+
+**Options:**
+
+- `--sha256 <hash>`: Optional SHA256 hash of the source object.  
+  If omitted, add-url uses an ETag+source-derived placeholder OID and registers metadata without a local payload blob.
+
+**Notes:**
+
+- `add-url` no longer accepts per-command AWS credential flags.
+- S3 connection hints are resolved from environment/runtime config when needed (for example `AWS_REGION`, `AWS_ENDPOINT_URL`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`).
+- Registration happens on `git drs push`, not at `add-url` time.
+
+### `git drs version`
+
+Display Git DRS version information.
+
+```bash
+git drs bucket add-project production \
+  --organization HTAN_INT \
+  --project BForePC \
+  --path s3://cbds/htan-int/bforepc
+```
+
+## File Tracking and Hydration
+
+### `git drs track`
+
+Track files or patterns with Git-compatible pointer behavior.
+
+```bash
+git drs track "*.bam"
+git drs track "data/**"
+```
+
+Stage `.gitattributes` after changing tracked patterns.
+
+### `git drs untrack`
+
+Stop tracking patterns.
+
+```bash
+git drs untrack "*.bam"
+```
+
+### `git drs ls-files [pathspec...]`
+
+List tracked LFS-style files in the current checkout.
+
+```bash
+git drs ls-files
+git drs ls-files data/**
+git drs ls-files -I "*.bam"
+git drs ls-files --drs
+git drs ls-files -l --drs
+git drs ls-files -n results/**
+```
+
+Important behavior:
+
+- default mode is local-first and cheap
+- `*` means localized/hydrated in the worktree
+- `-` means the worktree still contains a pointer
+- `--drs` adds DRS registration checks
+
+Common flags:
+
+- `-I, --include <pattern>`: include filter; may be repeated
+- `-l, --long`: long output
+- `-n, --name-only`: path-only output
+- `--json`: structured output
+- `--drs`: check DRS registration status
+
+### `git drs pull`
+
+Hydrate tracked pointer files in the current checkout.
+
+```bash
+git drs pull
+git drs pull -I "*.bam"
+git drs pull -I "data/**" -I "results/*.txt"
+git drs pull --dry-run -I "results/**"
+```
+
+Important behavior:
+
+- `git drs pull` does not run `git pull`
+- it only hydrates tracked pointer files already present in the current checkout
+- include matching is against repo-relative paths
+
+Common flags:
+
+- `-I, --include <pattern>`: include filter; may be repeated
+- `--dry-run`: show what would be hydrated without downloading
+
+## Object Registration and Push
+
+### `git drs push [remote-name]`
+
+Register and upload tracked objects, then rely on normal Git push for refs.
+
+```bash
+git drs push
+git drs push production
+```
+
+What it does:
+
+- resolves local pointer/object metadata
+- uploads local bytes when needed
+- registers object metadata with the target Syfon instance
+- reconciles committed deletes derived from the pushed ref delta
+
+Notes:
+
+- delete reconciliation is Git-history-derived; there is no local delete-intent sidecar state
+- `git drs push` uses the current branch upstream as the delete diff base when one exists
+- plain `git push` uses the managed `pre-push` hook, which receives authoritative old/new SHAs from Git
+
+### `git drs add-url <object-url-or-key> [path]`
+
+Create a pointer and local metadata for an object that already exists in provider storage.
+
+```bash
+git drs add-url path/to/object.bin data/from-bucket.bin --scheme s3
+git drs add-url s3://my-bucket/path/to/object.bin data/from-bucket.bin
+git drs add-url s3://my-bucket/path/to/object.bin data/from-bucket.bin --sha256 <hex>
+```
+
+Notes:
+
+- object-key mode resolves against the configured bucket scope
+- explicit provider URL mode remains supported
+- `--scheme` is required for object-key mode
+
+### `git drs add-ref <drs-id> <path>`
+
+Add a local pointer file for an existing DRS object.
+
+```bash
+git drs add-ref drs://example/object-id data/object.bin
+```
+
+### `git drs query <drs-id>`
+
+Query a DRS object by ID.
+
+```bash
+git drs query drs://example/object-id
+```
+
+## Metadata Copy
+
+### `git drs copy-records [source-remote] <target-remote> <organization/project>`
+
+Copy Syfon metadata records from one remote to another for a single project scope.
+
+```bash
+git drs copy-records prod HTAN_INT/BForePC
+git drs copy-records dev prod HTAN_INT/BForePC
+```
+
+Behavior:
+
+- with one remote arg:
+  - source defaults to the configured default remote
+  - arg is treated as the target remote
+- with two remote args:
+  - first is source
+  - second is target
+- copies metadata only, not object bytes
+
+Merge behavior for existing target records:
+
+- match by DID
+- union `controlled_access`
+- union `access_methods`
+- preserve existing target metadata otherwise
+
+## Removed Legacy Commands
+
+These commands are gone from the cleaned CLI:
+
+- `git drs fetch`
+- `git drs list`
+- `git drs upload`
+- `git drs download`
+
+If older docs or notes mention them, treat those references as stale.

--- a/docs/tools/git-drs/docs/bucket-mapping.md
+++ b/docs/tools/git-drs/docs/bucket-mapping.md
@@ -1,0 +1,210 @@
+# Bucket Mapping
+
+Bucket mapping controls where a given `organization/project` scope stores object bytes.
+
+This is usually steward or admin setup, not normal end-user setup.
+
+## What You Configure
+
+There are three related layers:
+
+1. Bucket credentials on the server
+2. Organization-wide storage mapping
+3. Project-specific storage mapping
+
+The usual flow is:
+
+```bash
+git drs bucket add production \
+  --bucket cbds \
+  --region us-east-1 \
+  --access-key "$AWS_ACCESS_KEY_ID" \
+  --secret-key "$AWS_SECRET_ACCESS_KEY" \
+  --s3-endpoint https://s3.amazonaws.com
+
+git drs bucket add-organization production \
+  --organization HTAN_INT \
+  --path s3://cbds/htan-int
+
+git drs bucket add-project production \
+  --organization HTAN_INT \
+  --project BForePC \
+  --path s3://cbds/bforepc
+```
+
+## 1. Add Bucket Credentials
+
+Declare the storage credential on the target server:
+
+```bash
+git drs bucket add production \
+  --bucket cbds \
+  --region us-east-1 \
+  --access-key "$AWS_ACCESS_KEY_ID" \
+  --secret-key "$AWS_SECRET_ACCESS_KEY" \
+  --s3-endpoint https://s3.amazonaws.com
+```
+
+Notes:
+
+- this stores the bucket credential on the remote Syfon server
+- `production` is an optional remote name; if omitted, `origin` is used
+- `--s3-endpoint` is required by the current command surface
+
+## 2. Add an Organization Mapping
+
+Map an organization to a bucket path:
+
+```bash
+git drs bucket add-organization production \
+  --organization HTAN_INT \
+  --path s3://cbds/htan-int
+```
+
+This means:
+
+- bucket: `cbds`
+- base prefix for the organization: `htan-int`
+
+Every project in that organization can inherit this mapping.
+
+## 3. Add a Project Mapping
+
+Map a project to a path:
+
+```bash
+git drs bucket add-project production \
+  --organization HTAN_INT \
+  --project BForePC \
+  --path s3://cbds/bforepc
+```
+
+This adds a project-specific mapping for `HTAN_INT/BForePC`.
+
+## Path Format
+
+Both `add-organization` and `add-project` require `--path` in storage URL form:
+
+```bash
+s3://bucket/prefix
+gs://bucket/prefix
+azblob://bucket/prefix
+```
+
+Important behavior:
+
+- the bucket name is taken from the URL host
+- the persisted prefix is the path portion after the bucket
+- the bucket embedded in `--path` must match the resolved bucket
+
+## How Resolution Works
+
+When `git-drs` resolves the effective storage scope for an `organization/project`, it uses these rules:
+
+### If an organization mapping exists
+
+The organization mapping wins for the bucket.
+
+Then:
+
+- the organization prefix is used as the base
+- if a project mapping also exists, its prefix is appended
+
+Conceptually:
+
+```text
+effective_prefix = org_prefix + "/" + project_prefix
+```
+
+Example:
+
+- organization mapping: `s3://cbds/htan-int`
+- project mapping prefix: `bforepc`
+- effective result: bucket `cbds`, prefix `htan-int/bforepc`
+
+### If no organization mapping exists
+
+An exact project mapping can be used directly.
+
+Example:
+
+- project mapping: `s3://cbds/htan-int/bforepc`
+- effective result: bucket `cbds`, prefix `htan-int/bforepc`
+
+### If neither mapping exists
+
+Remote add and scoped upload setup will fail until a mapping is configured.
+
+## Choosing a Layout
+
+There are two common patterns.
+
+### Hierarchical organization-first layout
+
+```bash
+git drs bucket add-organization production \
+  --organization HTAN_INT \
+  --path s3://cbds/htan-int
+
+git drs bucket add-project production \
+  --organization HTAN_INT \
+  --project BForePC \
+  --path s3://cbds/bforepc
+```
+
+Result:
+
+- organization root: `htan-int`
+- project subpath: `bforepc`
+- effective project path: `htan-int/bforepc`
+
+Use this when all projects in an organization should live under one org root.
+
+### Exact project-only layout
+
+```bash
+git drs bucket add-project production \
+  --organization HTAN_INT \
+  --project BForePC \
+  --path s3://cbds/htan-int/bforepc
+```
+
+Use this when you do not want a separate organization-level mapping.
+
+## Overwriting Existing Mappings
+
+If a mapping already exists, the command fails unless you pass `--force`.
+
+Example:
+
+```bash
+git drs bucket add-project production \
+  --organization HTAN_INT \
+  --project BForePC \
+  --path s3://cbds/bforepc-v2 \
+  --force
+```
+
+## What End Users Usually Need To Know
+
+Usually, end users do not need to know the real bucket name.
+
+They only need:
+
+- the target `organization/project`
+- valid credentials
+- a configured remote
+
+Then they can run:
+
+```bash
+git drs remote add gen3 production HTAN_INT/BForePC --cred ~/.gen3/credentials.json
+```
+
+That remote setup resolves the bucket mapping from the server-side scope configuration.
+
+## Related Commands
+
+- [Getting Started](../getting-started.md)
+- [Commands Reference](../commands.md)
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/tools/git-drs/docs/developer-guide.md
+++ b/docs/tools/git-drs/docs/developer-guide.md
@@ -1,0 +1,159 @@
+# Developer Guide
+
+This guide covers Git DRS internals, architecture, and development information.
+
+## Architecture Overview
+
+Git DRS integrates with Git through several mechanisms:
+
+### Git Hooks Integration
+
+**Pre-commit Hook**: `git drs precommit`
+- Triggered automatically before each commit
+- Processes all staged files
+- Creates DRS records for new files
+- Only processes files that don't already exist on the DRS server
+- Prepares metadata for later upload during push
+
+**Pre-push Hook**: `git drs pre-push-prepare` (internal)
+- Triggered automatically before each push
+- Stages pending metadata for new/changed files
+- The hook prepares the repo for `git drs push` to complete upload and registration
+
+**Managed Push/Pull**
+- `git drs push` performs the register/upload workflow directly through the syfon client stack
+- `git drs pull` performs the download workflow directly through the syfon client stack
+
+### File Processing Flow
+
+```
+1. Developer: git add file.bam
+2. Developer: git commit -m "Add data"
+3. Git Hook: git drs precommit
+   - Creates DRS object metadata
+   - Stores in .git/drs/ directory
+4. Developer: git push
+5. Git Hook: git drs pre-push-prepare
+   - Stages pending metadata for DRS verify
+6. Git DRS:
+   - `git drs push` runs register/upload directly
+   - `git drs pull` runs download directly
+```
+
+## Current Data Path
+
+Git DRS no longer uses a custom transfer agent.
+
+- Upload path (primary): `git drs push` discovers local pointers, bulk-registers missing objects, checks validity, and uploads missing bits.
+- Download path (primary): `git drs pull` resolves object records and downloads into local object storage.
+
+## Repository Structure
+
+### Core Components
+
+```
+cmd/                    # CLI command implementations
+├── initialize/         # Repository initialization
+├── push/               # Register/upload workflow
+├── pull/               # Download workflow
+├── prepush/            # Pre-push metadata staging hook
+├── precommit/         # Pre-commit hook
+├── addurl/            # Cloud object URL reference handling
+└── ...
+
+client/                # DRS client implementations
+├── interface.go       # Client interface definitions
+├── DRS.go         # Gen3/DRS client
+└── drs-map.go        # File mapping utilities
+
+config/                # Configuration management
+└── config.go         # Config file handling
+
+drs/                   # DRS object utilities
+├── object.go         # DRS object structures
+└── util.go           # Utility functions
+
+lfs/                   # Pointer utilities
+└── lfs.go            # Pointer/discovery helpers
+
+utils/                 # Shared utilities
+├── common.go         # Common functions
+├── lfs-track.go      # Tracking utilities
+└── util.go           # General utilities
+```
+
+### Configuration System
+
+**Repository Configuration**: `.git/drs/config.yaml`
+```yaml
+current_server: gen3
+servers:
+  gen3:
+    endpoint: "https://data.example.org/"
+    profile: "myprofile"
+    project: "project-123"
+    bucket: "data-bucket"
+```
+
+### DRS Object Management
+
+Objects are stored in `.git/drs/objects/` during pre-commit and referenced during push/pull workflows.
+
+## Development Setup
+
+### Prerequisites
+
+- Go 1.26.2+
+- Access to a DRS server for testing
+
+### Building from Source
+
+```bash
+# Clone repository
+git clone https://github.com/calypr/git-drs.git
+cd git-drs
+
+# Install dependencies
+go mod download
+
+# Build
+go build
+
+# Install locally
+export PATH=$PATH:$(pwd)
+```
+
+### Development Workflow
+
+1. **Make changes** to source code
+2. **Build and test**:
+   ```bash
+   go build
+   go test ./...
+   ```
+3. **Test with real repository**:
+   ```bash
+   cd /path/to/test-repo
+   /path/to/git-drs/git-drs --help
+   ```
+
+## Debugging and Logging
+
+### Log Locations
+
+- **Commit logs**: `.git/drs/git-drs.log`
+- **Push/Pull logs**: `.git/drs/git-drs.log`
+
+
+## Testing
+
+### Unit Tests
+
+```bash
+# Test specific functionality
+go test ./utils -run TestTrack
+```
+
+### Integration Tests
+
+**WIP**

--- a/docs/tools/git-drs/docs/git-lfs.md
+++ b/docs/tools/git-drs/docs/git-lfs.md
@@ -1,0 +1,37 @@
+# Git LFS Compatibility
+
+`git-drs` supports Git LFS compatibility, but Git LFS is not required for normal `git-drs` workflows.
+
+Use this page if you are working with an older repository, a mixed environment, or a team workflow that still expects Git LFS concepts.
+
+## What Is Optional
+
+You do **not** need Git LFS installed in order to:
+
+- install `git-drs`
+- add a `git-drs` remote
+- track files with `git drs track`
+- upload with `git push` or `git drs push`
+- hydrate data with `git drs pull`
+
+## When Git LFS Still Matters
+
+Git LFS compatibility can still be useful when:
+
+- a repository already contains Git LFS-style pointer files
+- your team already understands Git LFS tracking patterns
+- you need to reason about clean/smudge filter behavior
+- you are debugging interoperability with older tooling
+
+`git-drs` uses a Git-compatible pointer workflow and fits into the same general filter architecture, but the day-to-day commands should come from `git-drs`, not from Git LFS.
+
+## Preferred Commands
+
+For current workflows, prefer:
+
+| Task | Use |
+|---|---|
+| Track files | `git drs track "*.bam"` |
+| See tracked files | `git drs ls-files` |
+| Hydrate file content | `git drs pull` |
+| Upload/register data | `git push` or `git drs push` |

--- a/docs/tools/git-drs/docs/remove-files.md
+++ b/docs/tools/git-drs/docs/remove-files.md
@@ -1,0 +1,59 @@
+# Removing Files
+
+There are two different questions when you remove a file from a `git-drs` repository:
+
+1. Do you just want to remove the path from Git?
+2. Do you also want the pushed deletion to reconcile remote DRS state for that object?
+
+For tracked `git-drs` files, the recommended command is `git drs rm`.
+
+## Which Command To Use
+
+### Use `git drs rm` for tracked `git-drs` files
+
+```bash
+git drs rm DATA/subject-123/vcf/sample1.vcf.gz
+```
+
+Use this when you want the supported Git-DRS delete workflow.
+
+What it does immediately:
+
+- validates that the path is a tracked `git-drs` file
+- removes the path from the worktree and index
+- stages the deletion through normal Git
+
+What happens later, when the deletion is committed and pushed:
+
+- `git-drs` derives deleted pointers from the pushed Git commit delta
+- if the object is still live somewhere else in the pushed repo state, only the local path deletion is reconciled
+- if the scoped record has exactly one `controlled_access` resource, the remote record is deleted
+- if the record has multiple `controlled_access` resources, only the current `organization/project` resource is removed
+
+### Use `git rm` for ordinary Git-managed files
+
+```bash
+git rm README.md
+```
+
+Use this for files that are not tracked by `git-drs`.
+
+## Typical Tracked-File Removal Flow
+
+```bash
+git drs rm DATA/subject-123/vcf/sample1.vcf.gz
+git commit -m "Remove sample"
+git drs push
+```
+
+That is the supported tracked-object delete flow.
+
+## Best Practice
+
+For data objects managed by `git-drs`, prefer:
+
+```bash
+git drs rm <path>
+git commit -m "Remove tracked object"
+git drs push
+```

--- a/docs/tools/git-drs/docs/troubleshooting.md
+++ b/docs/tools/git-drs/docs/troubleshooting.md
@@ -1,0 +1,409 @@
+# Troubleshooting
+
+Common issues and solutions for the cleaned `git-drs` CLI.
+
+> **Navigation:** [Getting Started](../getting-started.md) -> [Commands Reference](../commands.md) -> **Troubleshooting**
+
+## Frequently Asked Questions
+
+### Do I need to run `git drs init` each time?
+
+No.
+
+`git drs init` is repository setup. In most cases you do not need to run it manually at all, because `git drs remote add ...` now bootstraps that setup automatically when it is missing.
+
+Run it when:
+
+- you want to initialize repo-local `git-drs` state before adding any remote
+- you want to repair hooks/config wiring explicitly
+
+Do not run it every session:
+
+- not at the start of normal daily work
+- not after refreshing credentials
+- not after `git pull`
+
+What it changes:
+
+- creates `.git/drs/` repository-local state
+- sets up `git-drs` repository configuration and hooks
+- prepares the repo for managed pointer/register/hydration behavior
+
+### What if I run `git drs init` again?
+
+Usually nothing catastrophic, but it is unnecessary.
+
+If you did it accidentally:
+
+1. inspect what changed
+
+   ```bash
+   git status
+   git diff
+   ```
+
+2. if the changes are harmless, leave them alone or commit what you intended
+
+3. if you want to discard the uncommitted changes, use normal Git restore/reset flow carefully
+
+4. if hooks or repo-local state were repaired intentionally, keep the changes
+
+The right default is: inspect first, then decide whether anything actually needs to be reverted.
+
+### What does `git drs init` actually change?
+
+It prepares repository-local `git-drs` state:
+
+- `.git/drs/` metadata/state
+- hook/config wiring for `git-drs` workflows
+- the repo-local setup needed for pointer/register/hydration behavior
+
+Those changes persist in the clone. They are not something you redo per session.
+
+## When to Use Which Tool
+
+### Use `git-drs` for
+
+- repository-local `git-drs` setup
+- remote configuration
+- tracking rules
+- object hydration
+- DRS/Syfon metadata-oriented workflows
+
+Examples:
+
+- `git drs remote add gen3 ...`
+- `git drs remote remove ...`
+- `git drs init`
+- `git drs track`
+- `git drs ls-files`
+- `git drs pull`
+- `git drs add-url`
+- `git drs copy-records`
+
+### Use normal Git for
+
+- branch and commit movement
+- staging and committing
+- ordinary ref push/pull operations
+
+Examples:
+
+- `git add`
+- `git commit`
+- `git push`
+- `git pull`
+
+## First Principles
+
+Before debugging behavior, keep the command split straight:
+
+- `git pull`
+  - updates commits, branches, and checkout state
+- `git drs pull`
+  - hydrates tracked pointer files already present in the current checkout
+- `git drs ls-files`
+  - shows tracked files and localization state
+
+If you blur those together, the failure modes get confusing.
+
+## Common Error Patterns
+
+### Failed commit or pointer conversion issues
+
+Check these in order:
+
+1. confirm the file pattern was tracked before the add/commit flow
+
+   ```bash
+   git drs track
+   ```
+
+2. confirm `.gitattributes` was staged after changing tracking rules
+
+   ```bash
+   git status
+   ```
+
+3. confirm the file shows up in the tracked inventory
+
+   ```bash
+   git drs ls-files
+   ```
+
+4. inspect `.git/drs/` logs if the hook path failed
+
+### Failed push: upload, register, or auth
+
+Check:
+
+```bash
+git drs remote list
+git drs ls-files --drs
+```
+
+Then retry with higher Git/HTTP verbosity if needed:
+
+```bash
+GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push
+```
+
+### Failed clone or fresh checkout still has pointer files
+
+That usually just means hydration has not happened yet.
+
+Run:
+
+```bash
+git drs remote list
+git drs pull
+```
+
+If the repo has never had a `git-drs` remote configured, run `git drs remote add ...` first. That command will also install the repo-local hooks/config.
+
+### Network timeout during push or download
+
+If you use SSH remotes, keepalives help:
+
+```
+Host github.com
+    TCPKeepAlive yes
+    ServerAliveInterval 30
+```
+
+## Common Problems
+
+### `git drs pull` did not update my branch
+
+That is expected.
+
+`git drs pull` no longer runs `git pull`.
+
+Use:
+
+```bash
+git pull
+git drs pull
+```
+
+### `git drs ls-files` does not show my file
+
+Check these in order:
+
+1. is the path actually tracked?
+
+```bash
+git drs track
+```
+
+2. did you stage `.gitattributes` after adding the pattern?
+
+```bash
+git add .gitattributes
+```
+
+3. is the file part of the current checkout?
+
+```bash
+git ls-files -- path/to/file
+```
+
+4. inspect the local view:
+
+```bash
+git drs ls-files -l
+```
+
+### `git remote remove` did not remove my `git-drs` remote
+
+That is expected.
+
+Git remotes and `git-drs` remotes live in different config domains.
+
+Use:
+
+```bash
+git drs remote list
+git drs remote remove <name>
+```
+
+or:
+
+```bash
+git drs remote rm <name>
+```
+
+### `git drs pull` does nothing
+
+That usually means one of these:
+
+- the current checkout already has localized bytes
+- there are no tracked pointer files matching your include filters
+- the file is not tracked by `git-drs`
+
+Check:
+
+```bash
+git drs ls-files
+git drs ls-files -I "*.bam"
+git drs pull --dry-run -I "*.bam"
+```
+
+### `git drs pull` still leaves pointer files
+
+Check DRS registration status:
+
+```bash
+git drs ls-files --drs
+```
+
+If the object is not registered or not resolvable from the configured remote, hydration cannot succeed.
+
+Also confirm the remote configuration:
+
+```bash
+git drs remote list
+```
+
+If needed, inspect the detailed logs:
+
+```bash
+ls -la .git/drs/
+```
+
+### `git drs remote add gen3` fails on bucket mapping
+
+Current shape:
+
+```bash
+git drs remote add gen3 [remote-name] <organization/project> [--cred <file> | --token <token>]
+```
+
+If this fails, the likely cause is missing bucket mapping for that scope.
+
+That mapping is usually steward/admin setup, not something the end user invents ad hoc.
+
+### My credentials expired
+
+Refresh by re-adding the remote with a new credential file or token:
+
+```bash
+git drs remote add gen3 production HTAN_INT/BForePC --cred /path/to/new-credentials.json
+```
+
+You do not need to run `git drs init` again.
+
+What `git-drs` does automatically:
+
+- if the stored access token is expired but the stored API key is still valid, `git-drs` will attempt to refresh the access token
+- if the API key itself is expired, revoked, or replaced, you need to re-run `git drs remote add gen3 ...`
+
+How to think about recovery:
+
+- token expired, key still valid:
+  - often automatic
+- key expired or replaced:
+  - rerun `git drs remote add gen3 ... --cred ...` or `--token ...`
+
+How to check what is in use:
+
+```bash
+git drs remote list
+```
+
+And for the underlying Gen3 profile data:
+
+- inspect `~/.gen3/gen3_client_config.ini`
+
+If you want the least surprising fix, just re-run `git drs remote add gen3 ...` with the current credential file. That updates the stored profile and repo token plumbing in one step.
+
+### `git push` fails with upload or register errors
+
+Check:
+
+```bash
+git drs remote list
+git drs ls-files --drs
+```
+
+Typical root causes:
+
+- expired credentials
+- wrong remote selected
+- missing server-side bucket mapping
+- object registration or upload permissions missing for the target scope
+
+### Files are not being tracked
+
+Symptoms:
+
+- large files were committed directly to Git
+- `git drs ls-files` does not show the file
+
+Recovery:
+
+```bash
+git drs track "*.bam"
+git add .gitattributes
+git rm --cached large-file.bam
+git add large-file.bam
+git commit -m "Track large file with git-drs"
+```
+
+### Cloned repo only has pointer files
+
+That is normal.
+
+After cloning:
+
+```bash
+git drs pull
+```
+
+Or hydrate only what you need:
+
+```bash
+git drs pull -I "*.bam"
+```
+
+## Debugging Workflow
+
+When behavior is unclear, use this sequence:
+
+```bash
+git drs remote list
+git drs track
+git drs ls-files -l
+git drs ls-files --drs
+git drs pull --dry-run
+```
+
+That usually tells you whether the problem is:
+
+- tracking
+- hydration state
+- DRS registration
+- remote configuration
+
+## Log and State Inspection
+
+Useful checks:
+
+```bash
+git drs remote list
+git drs track
+git drs ls-files -l
+git drs ls-files --drs
+ls -la .git/drs/
+```
+
+## Removed Commands
+
+If you see old notes mentioning these, ignore them:
+
+- `git drs fetch`
+- `git drs list`
+- `git drs upload`
+- `git drs download`
+
+Those were removed from the cleaned CLI surface.

--- a/docs/tools/git-drs/getting-started.md
+++ b/docs/tools/git-drs/getting-started.md
@@ -1,0 +1,139 @@
+# Getting Started
+
+This page assumes you already completed [Quick Start](quickstart.md).
+
+Quick Start gets you running. This page explains how to think about `git-drs` once the repo is connected and usable.
+
+## The Mental Model
+
+Use the tools at the right layer:
+
+- use `git` for commits, branches, merges, and `git pull`
+- use `git-drs` for remote configuration, tracking rules, object hydration, upload/registration, and tracked-file delete reconciliation
+
+The most important distinction is:
+
+- `git pull` updates commits and checkout state
+- `git drs pull` hydrates tracked pointer files already present in the checkout
+
+## The Setup Command
+
+The standard setup command is:
+
+```bash
+git drs remote add gen3 production <organization/project> --cred ~/.gen3/credentials.json
+```
+
+That command:
+
+- stores the remote configuration
+- imports or refreshes credentials
+- bootstraps repo-local `git-drs` wiring when it is missing
+
+## The Two Common Workflows
+
+### Existing Repository
+
+```bash
+git clone <repo-url>
+cd <repo-name>
+git drs remote add gen3 production <organization/project> --cred ~/.gen3/credentials.json
+git drs pull
+```
+
+### New Repository
+
+```bash
+mkdir my-data-repo
+cd my-data-repo
+git init
+git drs remote add gen3 production <organization/project> --cred ~/.gen3/credentials.json
+git drs track "*.bam"
+git add .gitattributes
+git commit -m "Configure tracked files"
+```
+
+## Typical Workflow
+
+Most work reduces to this loop:
+
+1. update Git history
+
+   ```bash
+   git pull
+   ```
+
+2. hydrate tracked files when needed
+
+   ```bash
+   git drs pull
+   ```
+
+   To hydrate only part of a repository instead of everything, use include filters:
+
+   ```bash
+   git drs pull -I "data/sample.bam"
+   git drs pull -I "*.vcf.gz"
+   ```
+
+3. edit or add files normally
+
+   ```bash
+   git add ...
+   git commit -m "..."
+   ```
+
+4. push data changes
+
+   ```bash
+   git drs push
+   ```
+
+`git drs push` handles the DRS upload flow and the Git push flow together.
+
+Use plain `git push` when you only want to push Git-only changes and do not want the `git-drs` upload stage.
+
+## The Core Tasks
+
+### Track files
+
+```bash
+git drs track "*.bam"
+git drs track "data/**"
+```
+
+Always review and stage `.gitattributes` after changing tracking rules.
+
+### Inspect local state
+
+```bash
+git drs ls-files
+git drs ls-files -l
+git drs ls-files --drs
+```
+
+Interpretation:
+
+- `*` means the worktree has localized bytes
+- `-` means the worktree still has a pointer
+
+### Remove tracked files
+
+```bash
+git drs rm sample.bam
+git commit -m "Remove sample"
+git drs push
+```
+
+That is the supported delete flow for tracked `git-drs` objects. For the fuller decision tree, see [Removing Files](docs/remove-files.md).
+
+### Refresh credentials
+
+```bash
+git drs remote add gen3 production <organization/project> --cred /path/to/new-credentials.json
+```
+
+## Read Next
+
+- [Commands Reference](commands.md) for exact command syntax
+- [Troubleshooting](troubleshooting.md) when a real workflow breaks

--- a/docs/tools/git-drs/installation.md
+++ b/docs/tools/git-drs/installation.md
@@ -1,0 +1,93 @@
+# Installation Guide
+
+This page is only about getting the `git-drs` binary onto a machine. It does not teach the repository workflow.
+
+If you want the shortest onboarding path, use [Quick Start](quickstart.md). If you want the workflow explained, use [Getting Started](getting-started.md).
+
+## Release Install
+
+This guide uses release `v0.6.0`.
+
+- [GitHub Releases](https://github.com/calypr/git-drs/releases)
+
+=== "macOS (Apple Silicon)"
+
+    ```bash
+    curl -L -o git-drs-darwin-arm64-v0.6.0.tar.gz \
+      https://github.com/calypr/git-drs/releases/download/v0.6.0/git-drs-darwin-arm64-v0.6.0.tar.gz
+    tar -xzf git-drs-darwin-arm64-v0.6.0.tar.gz
+    install -m 0755 git-drs "$HOME/.local/bin/git-drs"
+    ```
+
+=== "macOS (Intel)"
+
+    ```bash
+    curl -L -o git-drs-darwin-amd64-v0.6.0.tar.gz \
+      https://github.com/calypr/git-drs/releases/download/v0.6.0/git-drs-darwin-amd64-v0.6.0.tar.gz
+    tar -xzf git-drs-darwin-amd64-v0.6.0.tar.gz
+    install -m 0755 git-drs "$HOME/.local/bin/git-drs"
+    ```
+
+=== "Linux (x86_64)"
+
+    ```bash
+    curl -L -o git-drs-linux-amd64-v0.6.0.tar.gz \
+      https://github.com/calypr/git-drs/releases/download/v0.6.0/git-drs-linux-amd64-v0.6.0.tar.gz
+    tar -xzf git-drs-linux-amd64-v0.6.0.tar.gz
+    install -m 0755 git-drs "$HOME/.local/bin/git-drs"
+    ```
+
+=== "Linux (arm64)"
+
+    ```bash
+    curl -L -o git-drs-linux-arm64-v0.6.0.tar.gz \
+      https://github.com/calypr/git-drs/releases/download/v0.6.0/git-drs-linux-arm64-v0.6.0.tar.gz
+    tar -xzf git-drs-linux-arm64-v0.6.0.tar.gz
+    install -m 0755 git-drs "$HOME/.local/bin/git-drs"
+    ```
+
+=== "Windows"
+
+    There is no packaged Windows release in this flow. Build `git-drs` from source instead.
+
+## PATH
+
+If `$HOME/.local/bin` is not already in your shell path, add it in your shell startup file.
+
+Example:
+
+```bash
+export PATH="$PATH:$HOME/.local/bin"
+```
+
+## Verify The Install
+
+```bash
+git-drs version
+git drs version
+```
+
+## Build From Source
+
+Use this when you need a local development build or a platform without a packaged release.
+
+```bash
+git clone https://github.com/calypr/git-drs.git
+cd git-drs
+go build
+```
+
+Then move or copy the built binary somewhere on your `PATH`.
+
+## What Installation Does Not Do
+
+Installing the binary does not configure a repository. Repository-local setup now happens when you run:
+
+```bash
+git drs remote add ...
+```
+
+## Read Next
+
+- [Quick Start](quickstart.md) for first setup on a real repo
+- [Getting Started](getting-started.md) for the workflow model

--- a/docs/tools/git-drs/quickstart.md
+++ b/docs/tools/git-drs/quickstart.md
@@ -1,0 +1,121 @@
+# Quick Start
+
+This page is intentionally minimal. It gets a new user from zero to a working `git-drs` repository with as little explanation as possible.
+
+If you want the workflow explained after setup, continue to [Getting Started](getting-started.md).
+
+## 1. Install `git-drs`
+
+This quick start uses release `v0.6.0`.
+
+- [GitHub Releases](https://github.com/calypr/git-drs/releases)
+
+=== "macOS (Apple Silicon)"
+
+    ```bash
+    curl -L -o git-drs-darwin-arm64-v0.6.0.tar.gz \
+      https://github.com/calypr/git-drs/releases/download/v0.6.0/git-drs-darwin-arm64-v0.6.0.tar.gz
+    tar -xzf git-drs-darwin-arm64-v0.6.0.tar.gz
+    install -m 0755 git-drs "$HOME/.local/bin/git-drs"
+    ```
+
+=== "macOS (Intel)"
+
+    ```bash
+    curl -L -o git-drs-darwin-amd64-v0.6.0.tar.gz \
+      https://github.com/calypr/git-drs/releases/download/v0.6.0/git-drs-darwin-amd64-v0.6.0.tar.gz
+    tar -xzf git-drs-darwin-amd64-v0.6.0.tar.gz
+    install -m 0755 git-drs "$HOME/.local/bin/git-drs"
+    ```
+
+=== "Linux (x86_64)"
+
+    ```bash
+    curl -L -o git-drs-linux-amd64-v0.6.0.tar.gz \
+      https://github.com/calypr/git-drs/releases/download/v0.6.0/git-drs-linux-amd64-v0.6.0.tar.gz
+    tar -xzf git-drs-linux-amd64-v0.6.0.tar.gz
+    install -m 0755 git-drs "$HOME/.local/bin/git-drs"
+    ```
+
+=== "Linux (arm64)"
+
+    ```bash
+    curl -L -o git-drs-linux-arm64-v0.6.0.tar.gz \
+      https://github.com/calypr/git-drs/releases/download/v0.6.0/git-drs-linux-arm64-v0.6.0.tar.gz
+    tar -xzf git-drs-linux-arm64-v0.6.0.tar.gz
+    install -m 0755 git-drs "$HOME/.local/bin/git-drs"
+    ```
+
+=== "Windows"
+
+    There is no packaged Windows release in this flow. Build `git-drs` from source instead.
+
+Verify:
+
+```bash
+git-drs version
+```
+
+## 2. Get Credentials
+
+Download your Gen3 API credentials JSON from your commons profile page and save it somewhere stable, for example:
+
+```bash
+~/.gen3/credentials.json
+```
+
+Typical flow:
+
+1. Sign in to the Gen3 portal.
+2. Open your profile page.
+3. Click `Create API Key`.
+4. Download the JSON file.
+5. Save it somewhere stable.
+
+## 3. Connect An Existing Repository
+
+```bash
+git clone <repo-url>
+cd <repo-name>
+git drs remote add gen3 production <organization/project> --cred ~/.gen3/credentials.json
+git drs pull
+```
+
+Use this path when the repository already contains tracked pointers and you want local file contents.
+
+## 4. Start A New Repository
+
+```bash
+mkdir my-data-repo
+cd my-data-repo
+git init
+git drs remote add gen3 production <organization/project> --cred ~/.gen3/credentials.json
+git drs track "*.bam"
+git add .gitattributes
+git commit -m "Configure tracked files"
+```
+
+## 5. Day-One Commands
+
+Pull Git history:
+
+```bash
+git pull
+```
+
+Hydrate tracked files:
+
+```bash
+git drs pull
+```
+
+Upload/register tracked objects:
+
+```bash
+git drs push
+```
+
+## Read Next
+
+- [Getting Started](getting-started.md) for the workflow model
+- [Commands Reference](commands.md) for exact command behavior

--- a/docs/tools/git-drs/troubleshooting.md
+++ b/docs/tools/git-drs/troubleshooting.md
@@ -1,0 +1,409 @@
+# Troubleshooting
+
+Common issues and solutions for the cleaned `git-drs` CLI.
+
+> **Navigation:** [Getting Started](getting-started.md) -> [Commands Reference](commands.md) -> **Troubleshooting**
+
+## Frequently Asked Questions
+
+### Do I need to run `git drs init` each time?
+
+No.
+
+`git drs init` is repository setup. In most cases you do not need to run it manually at all, because `git drs remote add ...` now bootstraps that setup automatically when it is missing.
+
+Run it when:
+
+- you want to initialize repo-local `git-drs` state before adding any remote
+- you want to repair hooks/config wiring explicitly
+
+Do not run it every session:
+
+- not at the start of normal daily work
+- not after refreshing credentials
+- not after `git pull`
+
+What it changes:
+
+- creates `.git/drs/` repository-local state
+- sets up `git-drs` repository configuration and hooks
+- prepares the repo for managed pointer/register/hydration behavior
+
+### What if I run `git drs init` again?
+
+Usually nothing catastrophic, but it is unnecessary.
+
+If you did it accidentally:
+
+1. inspect what changed
+
+   ```bash
+   git status
+   git diff
+   ```
+
+2. if the changes are harmless, leave them alone or commit what you intended
+
+3. if you want to discard the uncommitted changes, use normal Git restore/reset flow carefully
+
+4. if hooks or repo-local state were repaired intentionally, keep the changes
+
+The right default is: inspect first, then decide whether anything actually needs to be reverted.
+
+### What does `git drs init` actually change?
+
+It prepares repository-local `git-drs` state:
+
+- `.git/drs/` metadata/state
+- hook/config wiring for `git-drs` workflows
+- the repo-local setup needed for pointer/register/hydration behavior
+
+Those changes persist in the clone. They are not something you redo per session.
+
+## When to Use Which Tool
+
+### Use `git-drs` for
+
+- repository-local `git-drs` setup
+- remote configuration
+- tracking rules
+- object hydration
+- DRS/Syfon metadata-oriented workflows
+
+Examples:
+
+- `git drs remote add gen3 ...`
+- `git drs remote remove ...`
+- `git drs init`
+- `git drs track`
+- `git drs ls-files`
+- `git drs pull`
+- `git drs add-url`
+- `git drs copy-records`
+
+### Use normal Git for
+
+- branch and commit movement
+- staging and committing
+- ordinary ref push/pull operations
+
+Examples:
+
+- `git add`
+- `git commit`
+- `git push`
+- `git pull`
+
+## First Principles
+
+Before debugging behavior, keep the command split straight:
+
+- `git pull`
+  - updates commits, branches, and checkout state
+- `git drs pull`
+  - hydrates tracked pointer files already present in the current checkout
+- `git drs ls-files`
+  - shows tracked files and localization state
+
+If you blur those together, the failure modes get confusing.
+
+## Common Error Patterns
+
+### Failed commit or pointer conversion issues
+
+Check these in order:
+
+1. confirm the file pattern was tracked before the add/commit flow
+
+   ```bash
+   git drs track
+   ```
+
+2. confirm `.gitattributes` was staged after changing tracking rules
+
+   ```bash
+   git status
+   ```
+
+3. confirm the file shows up in the tracked inventory
+
+   ```bash
+   git drs ls-files
+   ```
+
+4. inspect `.git/drs/` logs if the hook path failed
+
+### Failed push: upload, register, or auth
+
+Check:
+
+```bash
+git drs remote list
+git drs ls-files --drs
+```
+
+Then retry with higher Git/HTTP verbosity if needed:
+
+```bash
+GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push
+```
+
+### Failed clone or fresh checkout still has pointer files
+
+That usually just means hydration has not happened yet.
+
+Run:
+
+```bash
+git drs remote list
+git drs pull
+```
+
+If the repo has never had a `git-drs` remote configured, run `git drs remote add ...` first. That command will also install the repo-local hooks/config.
+
+### Network timeout during push or download
+
+If you use SSH remotes, keepalives help:
+
+```
+Host github.com
+    TCPKeepAlive yes
+    ServerAliveInterval 30
+```
+
+## Common Problems
+
+### `git drs pull` did not update my branch
+
+That is expected.
+
+`git drs pull` no longer runs `git pull`.
+
+Use:
+
+```bash
+git pull
+git drs pull
+```
+
+### `git drs ls-files` does not show my file
+
+Check these in order:
+
+1. is the path actually tracked?
+
+```bash
+git drs track
+```
+
+2. did you stage `.gitattributes` after adding the pattern?
+
+```bash
+git add .gitattributes
+```
+
+3. is the file part of the current checkout?
+
+```bash
+git ls-files -- path/to/file
+```
+
+4. inspect the local view:
+
+```bash
+git drs ls-files -l
+```
+
+### `git remote remove` did not remove my `git-drs` remote
+
+That is expected.
+
+Git remotes and `git-drs` remotes live in different config domains.
+
+Use:
+
+```bash
+git drs remote list
+git drs remote remove <name>
+```
+
+or:
+
+```bash
+git drs remote rm <name>
+```
+
+### `git drs pull` does nothing
+
+That usually means one of these:
+
+- the current checkout already has localized bytes
+- there are no tracked pointer files matching your include filters
+- the file is not tracked by `git-drs`
+
+Check:
+
+```bash
+git drs ls-files
+git drs ls-files -I "*.bam"
+git drs pull --dry-run -I "*.bam"
+```
+
+### `git drs pull` still leaves pointer files
+
+Check DRS registration status:
+
+```bash
+git drs ls-files --drs
+```
+
+If the object is not registered or not resolvable from the configured remote, hydration cannot succeed.
+
+Also confirm the remote configuration:
+
+```bash
+git drs remote list
+```
+
+If needed, inspect the detailed logs:
+
+```bash
+ls -la .git/drs/
+```
+
+### `git drs remote add gen3` fails on bucket mapping
+
+Current shape:
+
+```bash
+git drs remote add gen3 [remote-name] <organization/project> [--cred <file> | --token <token>]
+```
+
+If this fails, the likely cause is missing bucket mapping for that scope.
+
+That mapping is usually steward/admin setup, not something the end user invents ad hoc.
+
+### My credentials expired
+
+Refresh by re-adding the remote with a new credential file or token:
+
+```bash
+git drs remote add gen3 production HTAN_INT/BForePC --cred /path/to/new-credentials.json
+```
+
+You do not need to run `git drs init` again.
+
+What `git-drs` does automatically:
+
+- if the stored access token is expired but the stored API key is still valid, `git-drs` will attempt to refresh the access token
+- if the API key itself is expired, revoked, or replaced, you need to re-run `git drs remote add gen3 ...`
+
+How to think about recovery:
+
+- token expired, key still valid:
+  - often automatic
+- key expired or replaced:
+  - rerun `git drs remote add gen3 ... --cred ...` or `--token ...`
+
+How to check what is in use:
+
+```bash
+git drs remote list
+```
+
+And for the underlying Gen3 profile data:
+
+- inspect `~/.gen3/gen3_client_config.ini`
+
+If you want the least surprising fix, just re-run `git drs remote add gen3 ...` with the current credential file. That updates the stored profile and repo token plumbing in one step.
+
+### `git push` fails with upload or register errors
+
+Check:
+
+```bash
+git drs remote list
+git drs ls-files --drs
+```
+
+Typical root causes:
+
+- expired credentials
+- wrong remote selected
+- missing server-side bucket mapping
+- object registration or upload permissions missing for the target scope
+
+### Files are not being tracked
+
+Symptoms:
+
+- large files were committed directly to Git
+- `git drs ls-files` does not show the file
+
+Recovery:
+
+```bash
+git drs track "*.bam"
+git add .gitattributes
+git rm --cached large-file.bam
+git add large-file.bam
+git commit -m "Track large file with git-drs"
+```
+
+### Cloned repo only has pointer files
+
+That is normal.
+
+After cloning:
+
+```bash
+git drs pull
+```
+
+Or hydrate only what you need:
+
+```bash
+git drs pull -I "*.bam"
+```
+
+## Debugging Workflow
+
+When behavior is unclear, use this sequence:
+
+```bash
+git drs remote list
+git drs track
+git drs ls-files -l
+git drs ls-files --drs
+git drs pull --dry-run
+```
+
+That usually tells you whether the problem is:
+
+- tracking
+- hydration state
+- DRS registration
+- remote configuration
+
+## Log and State Inspection
+
+Useful checks:
+
+```bash
+git drs remote list
+git drs track
+git drs ls-files -l
+git drs ls-files --drs
+ls -la .git/drs/
+```
+
+## Removed Commands
+
+If you see old notes mentioning these, ignore them:
+
+- `git drs fetch`
+- `git drs list`
+- `git drs upload`
+- `git drs download`
+
+Those were removed from the cleaned CLI surface.

--- a/docs/tools/syfon/configuration.md
+++ b/docs/tools/syfon/configuration.md
@@ -1,0 +1,481 @@
+# Server Configuration
+
+This page documents the actual `syfon serve --config <file>` server config model.
+
+The current config schema lives in `syfon/internal/config/config.go`. If the code and the docs ever disagree, the code wins.
+
+This page documents raw Syfon server config only. If you are deploying with the Helm chart, see [Kubernetes Deployment](kubernetes-deployment.md) for the chart-specific values layout and how it maps into this server config.
+
+## Example: Direct Syfon Config
+
+```yaml
+port: 8080
+
+auth:
+  mode: gen3
+
+routes:
+  docs: true
+  ga4gh: true
+  internal: true
+  lfs: true
+  metrics: true
+
+database:
+  postgres:
+    host: postgres-svc
+    port: 5432
+    user: syfon
+    password: REDACTED
+    database: syfon
+    sslmode: require
+
+credential_encryption:
+  master_key: REDACTED
+
+s3_credentials:
+  - bucket: cbds
+    provider: s3
+    endpoint: https://object.example.org
+    region: us-east-1
+    access_key: REDACTED
+    secret_key: REDACTED
+    resources:
+      - organization: cbds
+        org_path: organizations/cbds
+        projects:
+          - project_id: training
+            project_path: projects/training
+          - project_id: release_1
+            project_path: projects/release_1
+
+lfs:
+  max_batch_objects: 1000
+  max_batch_body_bytes: 10485760
+  request_limit_per_minute: 1200
+  bandwidth_limit_bytes_per_minute: 0
+
+signing:
+  default_expiry_seconds: 900
+```
+
+## Quick Reference
+
+If you only need the shape of the config, this is the short version:
+
+| Key | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `port` | integer | no | HTTP listen port for the Syfon server |
+| `database` | object | yes | Exactly one metadata backend: `sqlite` or `postgres` |
+| `auth` | object | yes | Authentication mode and auth-specific settings |
+| `routes` | object | no | Turn route groups on or off |
+| `credential_encryption` | object | recommended | Controls how stored bucket credentials are encrypted at rest |
+| `buckets` | array | no | Current bucket credential config field |
+| `s3_credentials` | array | no | Legacy alias for `buckets`; do not set both |
+| `bucket_scopes` | array | no | Explicit organization/project to bucket/path mappings |
+| `lfs` | object | no | Git LFS request sizing and rate limits |
+| `signing` | object | no | Signed URL expiry defaults |
+
+Most production configs need:
+
+- `database.postgres`
+- `auth.mode: gen3`
+- `credential_encryption`
+- `buckets` or legacy `s3_credentials`
+- either `resources` under each bucket entry or explicit `bucket_scopes`
+
+Most local configs need:
+
+- `database.sqlite`
+- `auth.mode: local`
+- one simple bucket entry
+
+Important constraints:
+
+- `buckets` is the current field.
+- `s3_credentials` is still accepted as a legacy alias.
+- You may specify only one of `buckets` or `s3_credentials`.
+- Internally, legacy `s3_credentials` entries are normalized into `buckets`.
+- `database` must contain exactly one backend.
+- `auth.mode` must be exactly `local` or `gen3`.
+
+## Detailed Reference
+
+The rest of this page is the detailed field-by-field reference with accepted formats, defaults, validation rules, and provider-specific behavior.
+
+## `port`
+
+```yaml
+port: 8080
+```
+
+- Type: integer
+- Default: `8080`
+- Environment override: `DRS_PORT`
+- Meaning: TCP port the Fiber HTTP server listens on inside the container or process
+
+## `database`
+
+Exactly one database backend must be configured.
+
+### SQLite
+
+```yaml
+database:
+  sqlite:
+    file: ./drs.db
+```
+
+- Type: string path
+- Good for local development and simple deployments.
+- Environment override: `DRS_DB_SQLITE_FILE`
+- Meaning: path to the SQLite database file used for object metadata, bucket credentials, and server state
+
+### PostgreSQL
+
+```yaml
+database:
+  postgres:
+    host: postgres-svc
+    port: 5432
+    user: syfon
+    password: REDACTED
+    database: syfon
+    sslmode: require
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `host` | string hostname or service DNS name | PostgreSQL server host |
+| `port` | integer | PostgreSQL server port |
+| `user` | string | PostgreSQL username |
+| `password` | string | PostgreSQL password |
+| `database` | string | Database name to open |
+| `sslmode` | string | Typical values: `disable`, `require`, `verify-ca`, `verify-full`; env-driven default is `require` |
+
+- Required for normal `auth.mode: gen3` deployments unless Gen3 mock auth is enabled for testing.
+- Environment overrides: `DRS_DB_HOST`, `DRS_DB_PORT`, `DRS_DB_USER`, `DRS_DB_PASSWORD`, `DRS_DB_DATABASE`, `DRS_DB_SSLMODE`
+
+## `auth`
+
+Supported auth modes:
+
+- `local`
+- `gen3`
+
+### Local
+
+```yaml
+auth:
+  mode: local
+  basic:
+    username: drs-user
+    password: drs-pass
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `auth.basic.username` | string | Username for built-in Basic Auth in local mode |
+| `auth.basic.password` | string | Password for built-in Basic Auth in local mode |
+| `auth.allow_unauthenticated` | boolean | Default `false`; development-only bypass when you do not want Basic Auth configured |
+
+Environment overrides: `DRS_AUTH_MODE`, `DRS_BASIC_AUTH_USER`, `DRS_BASIC_AUTH_PASSWORD`, `DRS_ALLOW_UNAUTHENTICATED_LOCAL`
+
+### Gen3
+
+```yaml
+auth:
+  mode: gen3
+  fence_url: https://fence.example.org
+  cache:
+    enabled: true
+    ttl_seconds: 60
+    negative_ttl_seconds: 15
+    max_entries: 10000
+    cleanup_seconds: 60
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `auth.fence_url` | string URL | Expected form: single `https://...` URL; trusted Fence issuer URL for JWT validation |
+| `auth.plugin_paths.authn` | string path | Copied into `SYFON_AUTHN_PLUGIN_PATH` for external authentication plugin execution |
+| `auth.plugin_paths.authz` | string path | Copied into `SYFON_AUTHZ_PLUGIN_PATH` for external authorization plugin execution |
+
+Cache fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `auth.cache.enabled` | boolean | Default at request time: `true`; turns the Gen3 auth decision cache on or off |
+| `auth.cache.ttl_seconds` | integer seconds | Default at request time: `45`; positive cache TTL for successful authz/authn results |
+| `auth.cache.negative_ttl_seconds` | integer seconds | Default at request time: `8`; negative cache TTL for denied or missing results |
+| `auth.cache.max_entries` | integer | Default at request time: `20000`; max number of cached auth results kept in memory |
+| `auth.cache.cleanup_seconds` | integer seconds | Default at request time: `60`; how often expired cache entries are swept |
+
+Mock auth fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `auth.mock.enabled` | boolean | Default `false`; enables the built-in fake Gen3 auth mode for local integration testing |
+| `auth.mock.require_auth_header` | boolean | Default `false`; if true, mock auth still requires an `Authorization` header |
+| `auth.mock.resources` | array of strings | Default at request time: `["/data_file"]`; Arborist-style resources granted by the mock authorizer |
+| `auth.mock.methods` | array of strings | Default at request time: `["*"]`; methods granted by the mock authorizer |
+
+Validation and behavior:
+
+- `auth.mode` is required and must be exactly `local` or `gen3`
+- `auth.mode: gen3` requires PostgreSQL unless mock auth is enabled
+- `auth.mode: local` requires `auth.basic.username` plus `auth.basic.password`, unless `auth.allow_unauthenticated: true`
+- `auth.basic.username` and `auth.basic.password` must be set together
+- mock auth is only allowed in `gen3` mode
+
+Environment overrides: `DRS_FENCE_URL`, `DRS_AUTH_MOCK_ENABLED`, `DRS_AUTH_MOCK_RESOURCES`, `DRS_AUTH_MOCK_METHODS`, `DRS_AUTH_MOCK_REQUIRE_AUTH_HEADER`, `DRS_AUTH_CACHE_ENABLED`, `DRS_AUTH_CACHE_TTL_SECONDS`, `DRS_AUTH_CACHE_NEGATIVE_TTL_SECONDS`, `DRS_AUTH_CACHE_MAX_ENTRIES`, `DRS_AUTH_CACHE_CLEANUP_SECONDS`
+
+## `routes`
+
+```yaml
+routes:
+  docs: true
+  ga4gh: true
+  internal: true
+  lfs: true
+  metrics: true
+```
+
+All of these default to `true`.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `routes.docs` | boolean | Swagger/OpenAPI docs routes |
+| `routes.ga4gh` | boolean | GA4GH DRS routes under `/ga4gh/drs/v1/...` |
+| `routes.internal` | boolean | Internal upload/download/index/bucket routes under `/data` and `/index` |
+| `routes.lfs` | boolean | Git LFS-compatible routes |
+| `routes.metrics` | boolean | Transfer and file-usage metrics routes |
+
+Environment overrides: `DRS_ENABLE_DOCS`, `DRS_ENABLE_GA4GH`, `DRS_ENABLE_INTERNAL`, `DRS_ENABLE_LFS`, `DRS_ENABLE_METRICS`
+
+## `credential_encryption`
+
+```yaml
+credential_encryption:
+  master_key: REDACTED
+  local_key_file: /var/lib/syfon/.syfon-credential-kek
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `credential_encryption.master_key` | string | KEK material for encrypting persisted bucket credentials; accepted formats: 32-character raw string, 64-character hex string, or base64-encoded 32-byte key; not an access token or password |
+| `credential_encryption.local_key_file` | string path | Path where Syfon loads or persists the server-local KEK; fallback order: `DRS_CREDENTIAL_LOCAL_KEY_FILE`, then next to the SQLite DB as `.syfon-credential-kek`, then `/app/.syfon-credential-kek` |
+
+Environment overrides: `DRS_CREDENTIAL_MASTER_KEY`, `DRS_CREDENTIAL_LOCAL_KEY_FILE`
+
+Use this to control how persisted bucket credentials are encrypted at rest. See also [Encryption](encryption.md).
+
+Operational note:
+
+- if `master_key` is omitted, Syfon can still run in local key-file mode and manage a KEK on disk
+- if bucket credentials are being persisted, encryption must still be valid at runtime
+
+## `buckets` and `s3_credentials`
+
+These entries define stored signing credentials.
+
+```yaml
+s3_credentials:
+  - bucket: cbds
+    provider: s3
+    endpoint: https://object.example.org
+    region: us-east-1
+    access_key: REDACTED
+    secret_key: REDACTED
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `bucket` | string | Storage bucket or container name used for signing |
+| `provider` | string | Storage provider selector |
+| `region` | string | Cloud region; required for `provider: s3` |
+| `access_key` | string | Provider credential identifier |
+| `secret_key` | string | Provider credential secret |
+| `endpoint` | string URL | Custom endpoint for S3-compatible systems or local object stores |
+| `resources` | array | Organization/project mapping rules used to derive bucket scopes automatically |
+
+What this entry actually does:
+
+- it tells Syfon which credential set should sign URLs for a given bucket
+- it optionally tells Syfon which Gen3 organizations and projects belong in that bucket
+- if `resources` is present, Syfon derives `bucket_scopes` entries automatically from it during config load
+
+### Supported providers
+
+Accepted provider names:
+
+- `s3`
+- `gcs`
+- `gs`
+- `azure`
+- `azblob`
+- `file`
+
+Normalization:
+
+- `gs` becomes `gcs`
+- `azblob` becomes `azure`
+
+### Required fields by provider
+
+For `provider: s3`:
+
+- `bucket` is required
+- `region` is required
+- `access_key` is required
+- `secret_key` is required
+- `endpoint` is optional and commonly used for S3-compatible systems
+
+Bucket-name validation is provider-specific. For `s3`, Syfon uses default AWS-style validation with lowercase letters, numbers, and hyphens in the usual 3-63 character range; if `endpoint` is set, it allows a looser S3-compatible bucket pattern. For `gcs`, Syfon allows lowercase letters, numbers, hyphens, underscores, and dots, but rejects `goog...` names and IP-address-like bucket names. For `azure`, Syfon allows lowercase letters, numbers, and hyphens, and rejects consecutive hyphens. For `file`, Syfon does not enforce bucket-name validation.
+
+For `gcs`, `azure`, and `file`, the validation rules are looser in config loading, but `bucket` and provider-appropriate runtime behavior still matter.
+
+## `resources`
+
+This is the part that usually does the heavy lifting for organization/project mapping.
+
+Example:
+
+```yaml
+s3_credentials:
+  - bucket: cbds
+    provider: s3
+    region: us-east-1
+    access_key: REDACTED
+    secret_key: REDACTED
+    resources:
+      - organization: cbds
+        org_path: organizations/cbds
+        projects:
+          - project_id: release_1
+            project_path: projects/release_1
+          - project_id: release_2
+            project_path: projects/release_2
+      - organization: root_only
+        org_path: roots/root_only
+```
+
+| Resource field | Type | Notes |
+| --- | --- | --- |
+| `organization` | string | Gen3 program / organization name |
+| `org_path` | string path fragment | Storage prefix to use for the organization root inside the bucket |
+| `projects` | array | Nested project-specific mappings under the organization |
+
+| Project field | Type | Notes |
+| --- | --- | --- |
+| `project_id` | string | Gen3 project identifier |
+| `project` | string | Alternate project field name accepted by config normalization |
+| `project_path` | string path fragment | Project-specific suffix joined under `org_path` |
+| `path` | string | Direct fully qualified storage path override such as `s3://bucket/prefix` |
+| `path_prefix` | string | Normalized prefix override inside the bucket |
+
+How this works:
+
+Each bucket credential can declare one or more organizations. Each organization can optionally declare nested project mappings. Syfon converts these mappings into `bucket_scopes` internally. `org_path` and `project_path` are joined into the final storage prefix unless a project declares `path` or `path_prefix`, in which case that explicit project mapping wins. If an organization has no `projects`, Syfon derives an organization-wide scope rooted at `org_path`.
+
+So a config like:
+
+```yaml
+resources:
+  - organization: cbds
+    org_path: organizations/cbds
+    projects:
+      - project_id: release_1
+        project_path: projects/release_1
+```
+
+derives a scope roughly equivalent to:
+
+```yaml
+bucket_scopes:
+  - organization: cbds
+    project_id: release_1
+    bucket: cbds
+    path_prefix: organizations/cbds/projects/release_1
+```
+
+## `bucket_scopes`
+
+You can also declare explicit scopes directly instead of deriving them from `resources`.
+
+```yaml
+bucket_scopes:
+  - organization: cbds
+    project_id: release_1
+    bucket: cbds
+    path_prefix: organizations/cbds/projects/release_1
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `organization` | string | Gen3 program / organization name |
+| `project_id` | string | Gen3 project id |
+| `bucket` | string | Bucket or container to use for this scope |
+| `path` | string URL-like storage path | Expected form: `s3://bucket/prefix` |
+| `path_prefix` | string path fragment | Normalized prefix under the bucket |
+| `organization_sub_path` | string path fragment | Organization-level composed-path fragment |
+| `project_sub_path` | string path fragment | Project-level composed-path fragment |
+
+Rules worth knowing:
+
+`organization` must be a Gen3 program name, not a storage path, and `project_id` must be a Gen3 project identifier, not a storage path. `path` may include a fully qualified storage path like `s3://bucket/prefix`, and `path_prefix` is the normalized prefix under the bucket and should not start with `/`. `organization_sub_path` and `project_sub_path` are a composed-path convenience mode. `path` cannot be combined with `organization_sub_path` or `project_sub_path`, and `path_prefix` cannot be combined with them either. When `path` is present, Syfon parses the provider from the URL scheme, extracts the bucket from the URL host, and normalizes the path into `path_prefix`. When `organization_sub_path` or `project_sub_path` is used, `bucket` becomes required. Syfon joins `organization_sub_path` and `project_sub_path` with normalized path cleaning, and every final scope must resolve to a bucket, either from `bucket` directly or from the bucket embedded in `path`.
+
+## `lfs`
+
+```yaml
+lfs:
+  max_batch_objects: 1000
+  max_batch_body_bytes: 10485760
+  request_limit_per_minute: 1200
+  bandwidth_limit_bytes_per_minute: 0
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `lfs.max_batch_objects` | integer | Default `1000`; max object count accepted in a single LFS batch request |
+| `lfs.max_batch_body_bytes` | integer bytes | Default `10485760` (10 MiB); max request body size accepted by the LFS batch endpoint |
+| `lfs.request_limit_per_minute` | integer | Default `1200`; per-client request-rate limit for the LFS middleware |
+| `lfs.bandwidth_limit_bytes_per_minute` | integer bytes | Default `0`; per-client bandwidth cap for LFS routes; `0` disables the cap |
+
+Environment overrides: `DRS_LFS_MAX_BATCH_OBJECTS`, `DRS_LFS_MAX_BATCH_BODY_BYTES`, `DRS_LFS_REQUEST_LIMIT_PER_MINUTE`, `DRS_LFS_BANDWIDTH_LIMIT_BYTES_PER_MINUTE`
+
+## `signing`
+
+```yaml
+signing:
+  default_expiry_seconds: 900
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `signing.default_expiry_seconds` | integer seconds | Default `900`; default lifetime for signed URLs when a caller does not request a custom expiry |
+
+Environment override: `DRS_SIGNING_DEFAULT_EXPIRY_SECONDS`
+
+## Practical Guidance
+
+For most production deployments:
+
+- use `auth.mode: gen3`
+- use PostgreSQL
+- enable all normal route groups unless you have a reason to reduce surface area
+- store credential encryption material outside the image
+- use `s3_credentials` or `buckets` plus `resources` when your bucket layout follows organization/project conventions
+- use explicit `bucket_scopes` when you need exact path control
+
+For local development:
+
+- use `auth.mode: local`
+- use SQLite
+- use a small local config file with one bucket credential
+
+## Related Pages
+
+- [Deployment](deployment.md)
+- [Encryption](encryption.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/tools/syfon/deployment.md
+++ b/docs/tools/syfon/deployment.md
@@ -1,0 +1,9 @@
+# Deployment
+
+Deployment guidance has moved:
+
+- [Quick Start](quickstart.md)
+- [Local Deployment](local-deployment.md)
+- [Kubernetes Deployment](kubernetes-deployment.md)
+
+For raw server config fields, use [Server Configuration](configuration.md).

--- a/docs/tools/syfon/encryption.md
+++ b/docs/tools/syfon/encryption.md
@@ -1,0 +1,56 @@
+# Credential Encryption
+
+This document describes the supported operator-facing credential encryption model for Syfon.
+
+Syfon encrypts persisted bucket credentials such as `access_key` and `secret_key` at rest.
+
+## Design
+
+Syfon uses envelope encryption (`enc:v2`):
+
+1. Generate a random 32-byte DEK per encrypted field write.
+2. Encrypt plaintext with DEK using AES-GCM.
+3. Wrap the DEK with a key manager KEK.
+4. Store an envelope containing:
+   - key manager name
+   - key identifier metadata
+   - wrapped DEK
+   - AES-GCM nonce
+   - ciphertext
+5. On read, unwrap DEK through the manager and decrypt.
+
+Legacy `enc:v1` values are still readable for backward compatibility.
+
+## Supported Mode
+
+For operator docs, the supported mode is the local KEK flow. Syfon keeps a server-side key-encryption key and uses it to wrap the per-secret data keys used for stored bucket credentials.
+
+## Local KEK Mode
+
+In local mode, Syfon uses a server-managed local KEK file.
+
+Key file path resolution:
+
+- `DRS_CREDENTIAL_LOCAL_KEY_FILE` if set
+- else `dirname(DRS_DB_SQLITE_FILE)/.syfon-credential-kek` if `DRS_DB_SQLITE_FILE` is set
+- else `/app/.syfon-credential-kek`
+
+Behavior:
+
+- If key file exists, it is loaded.
+- If missing, Syfon generates a new 32-byte key and writes it with restrictive permissions.
+
+Optional override:
+
+- `DRS_CREDENTIAL_MASTER_KEY` can explicitly set the local KEK.
+- Accepted formats:
+  - a 32-character raw string
+  - a 64-character hex string
+  - a base64-encoded 32-byte key
+
+## Operational Notes
+
+- Clients do not need to provide encryption keys.
+- Changing HTTP basic-auth credentials does not change the local KEK when using the default local key-file behavior.
+- Keep the local KEK file persisted with your DB volume in local deployments.
+- If you lose the KEK that was used to encrypt stored bucket credentials, Syfon will no longer be able to decrypt those credentials.

--- a/docs/tools/syfon/index.md
+++ b/docs/tools/syfon/index.md
@@ -1,0 +1,66 @@
+# Syfon
+
+<p align="center">
+  <img src="images/syfon-logo.png" alt="Syfon logo" width="400" />
+</p>
+
+A lightweight, production-grade implementation of a [GA4GH Data Repository Service (DRS)](https://ga4gh.github.io/data-repository-service-schemas/) server in Go.
+
+## Overview
+
+Syfon manages metadata for large data objects and provides secure, cloud-agnostic access via presigned URLs. It is designed for research data platforms that need reliable, auditable data transfer at scale.
+
+```mermaid
+graph LR
+    A[Client] -->|DRS API| B[Syfon Server]
+    B --> C[(SQLite / PostgreSQL)]
+    B -->|Presigned URLs| D[S3 / GCS / Azure]
+    B -->|Auth| E[Local / Gen3]
+```
+
+## Key Features
+
+- **GA4GH DRS compliance** — implements the standard DRS API for describing and accessing data objects, including bulk registration, retrieval, and access-method management
+- **Multi-cloud storage** — native support for S3 (and S3-compatible endpoints like MinIO, RGW, and RustFS), GCS, and Azure Blob via presigned URL generation
+- **Multipart upload and download** — explicit `init → part → complete` lifecycle with resumable semantics for very large files
+- **Flexible auth** — `local` mode for development (optional HTTP basic auth), `gen3` mode for production Gen3/Fence/Arborist integration
+- **Database flexibility** — SQLite for local/dev, PostgreSQL for production
+- **Credential encryption at rest** — envelope encryption (AES-GCM) with a local server-side KEK
+
+## Useful Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /healthz` | Health check |
+| `GET /service-info` | DRS service info |
+| `GET /index/swagger` | Swagger UI |
+| `GET /index/openapi.yaml` | OpenAPI spec |
+| `GET /ga4gh/drs/v1/objects/{id}` | Fetch DRS object |
+| `POST /ga4gh/drs/v1/objects/register` | Bulk register objects |
+| `POST /data/upload` | Request presigned upload URL |
+| `POST /data/multipart/init` | Initiate multipart upload |
+| `POST /index/bulk/sha256/validity` | Bulk SHA256 validity check |
+
+## Project Layout
+
+```
+syfon/
+├── apigen/         # Generated OpenAPI models (separate Go module)
+├── client/         # Go client SDK (separate Go module)
+├── cmd/            # CLI commands (serve, upload, download, version, ...)
+├── config/         # Config loading and validation
+├── db/             # Database interfaces, SQLite and PostgreSQL drivers
+├── internal/api/   # HTTP route handlers (DRS, internal, LFS, metrics)
+├── service/        # High-level DRS business logic
+├── urlmanager/     # Cloud storage signing and multipart logic
+└── version/        # Build and version info
+```
+
+## Next Steps
+
+- [Quick Start](quickstart.md) — first local run and smoke test
+- [Local Deployment](local-deployment.md) — SQLite plus `auth.mode: local` for development
+- [Kubernetes Deployment](kubernetes-deployment.md) — Helm-chart deployment with Gen3 and PostgreSQL
+- [Server Configuration](configuration.md) — raw Syfon config schema and field reference
+- [Encryption](encryption.md) — credential encryption at rest
+- [Troubleshooting](troubleshooting.md) — common issues and fixes

--- a/docs/tools/syfon/kubernetes-deployment.md
+++ b/docs/tools/syfon/kubernetes-deployment.md
@@ -1,0 +1,143 @@
+# Kubernetes Deployment
+
+This page documents the current [`helm/syfon`](https://github.com/calypr/gen3-helm/tree/ohsu-develop/helm/syfon) chart behavior and the values that matter most for a real deployment.
+
+For raw server config fields, see [Server Configuration](configuration.md). For local non-Kubernetes usage, see [Local Deployment](local-deployment.md).
+
+## What The Chart Does
+
+The current chart deploys Syfon by:
+
+- rendering `.Values.config` into a Kubernetes Secret
+- mounting that Secret at `/etc/drs/config.yaml`
+- starting the container with `serve --config /etc/drs/config.yaml`
+- injecting `DRS_DB_*` environment variables from a DB secret
+- optionally running a PostgreSQL init job that creates the app role, creates the app database, and applies the Syfon schema
+
+Important chart behavior:
+
+- in `gen3` mode, if `config.auth.fence_url` is empty, the chart fills it from `https://<global.hostname>/user`
+- the chart prefers `config.buckets`
+- if you still set `config.s3_credentials`, the chart normalizes that into `buckets` in the rendered config
+- the rendered Syfon config is stored as a Secret because it may contain bucket credentials and encryption material
+
+## Recommended K8s Shape
+
+For a normal Kubernetes deployment:
+
+- use `config.auth.mode: gen3`
+- use PostgreSQL
+- provide `credential_encryption.master_key`
+- configure bucket routing in `config.buckets`
+- leave the DB connection wiring to the chart's `postgres.*` secrets unless you are reusing existing secrets
+
+## Example Values
+
+```yaml
+image:
+  repository: quay.io/ohsu-comp-bio/syfon
+  tag: latest
+
+config:
+  port: 8080
+  auth:
+    mode: gen3
+    # Optional. If omitted, the chart uses https://<global.hostname>/user
+    fence_url: ""
+  routes:
+    docs: true
+    ga4gh: true
+    internal: true
+    lfs: true
+    metrics: true
+  credential_encryption:
+    master_key: REDACTED
+  buckets:
+    - bucket: cbds
+      provider: s3
+      region: us-east-1
+      endpoint: https://object.example.org
+      access_key: REDACTED
+      secret_key: REDACTED
+      resources:
+        - organization: cbds
+          org_path: organizations/cbds
+          projects:
+            - project_id: training
+              project_path: projects/training
+
+postgres:
+  app:
+    db_username: syfon_user
+    db_password: REDACTED
+    db_database: syfon_db
+    db_sslmode: disable
+  admin:
+    username: postgres
+    password: REDACTED
+    database: postgres
+  initJob:
+    enabled: true
+```
+
+## PostgreSQL Wiring
+
+The chart injects these into the Syfon container from the app DB secret:
+
+- `DRS_DB_HOST`
+- `DRS_DB_PORT`
+- `DRS_DB_USER`
+- `DRS_DB_PASSWORD`
+- `DRS_DB_DATABASE`
+- `DRS_DB_SSLMODE`
+
+If you do not provide explicit app/admin DB hosts, the chart resolves them from `global.postgres.master.*` when present, or falls back to the release-local PostgreSQL service naming pattern.
+
+## Reusing Existing Secrets
+
+If your cluster already has DB secrets, set:
+
+- `postgres.app.existingSecret`
+- `postgres.admin.existingSecret` when `postgres.initJob.enabled=true`
+
+The deployment still expects the app secret to expose:
+
+- `db_host`
+- `db_port`
+- `db_username`
+- `db_password`
+- `db_database`
+- `db_sslmode`
+
+## Init Job
+
+The init job is enabled by default.
+
+What it does:
+
+- waits for PostgreSQL readiness
+- creates or updates the app role
+- creates the app database if it does not exist
+- grants database privileges
+- applies the bundled Syfon PostgreSQL schema
+
+If your database is already provisioned and schema-managed elsewhere, you can disable it with:
+
+```yaml
+postgres:
+  initJob:
+    enabled: false
+```
+
+## Health Probes
+
+The chart configures both readiness and liveness probes against `GET /healthz` on the container `http` port. Tune them under:
+
+- `probes.liveness.*`
+- `probes.readiness.*`
+
+## Install
+
+```bash
+helm upgrade --install syfon ./helm/syfon
+```

--- a/docs/tools/syfon/local-deployment.md
+++ b/docs/tools/syfon/local-deployment.md
@@ -1,0 +1,80 @@
+# Local Deployment
+
+Local Syfon deployments should normally use SQLite plus `auth.mode: local`. You do not need PostgreSQL for a local run.
+
+If you only want the fastest first run, use [Quick Start](quickstart.md). If you need the raw config field reference, use [Server Configuration](configuration.md).
+
+## Recommended Local Shape
+
+For local development:
+
+- use `database.sqlite`
+- use `auth.mode: local`
+- use `auth.basic.*`
+- point bucket credentials at a local or dev S3-compatible endpoint such as MinIO
+
+## Example Local Config
+
+```yaml
+port: 8080
+
+auth:
+  mode: local
+  basic:
+    username: drs-user
+    password: drs-pass
+
+database:
+  sqlite:
+    file: ./data/drs_local.db
+
+credential_encryption:
+  local_key_file: ./data/.syfon-credential-kek
+
+buckets:
+  - bucket: local-bucket
+    provider: s3
+    region: us-east-1
+    endpoint: http://localhost:9000
+    access_key: minio-user
+    secret_key: minio-pass
+```
+
+Why this shape works:
+
+- SQLite keeps the metadata store self-contained
+- `auth.mode: local` avoids the Gen3, Fence, and PostgreSQL requirements
+- `local_key_file` gives the local credential KEK an explicit stable path next to the SQLite DB
+
+## Run From Source
+
+```bash
+go run . serve --config config.local.yaml
+```
+
+## Run With Docker
+
+```bash
+docker run \
+  -p 8080:8080 \
+  -v $(pwd)/config.local.yaml:/config.yaml \
+  -v $(pwd)/data:/data \
+  quay.io/ohsu-comp-bio/syfon:development serve --config /config.yaml
+```
+
+Use the published development image from Quay rather than building locally. Image tags are published at [Quay](https://quay.io/repository/ohsu-comp-bio/funnel?tab=tags).
+
+## Smoke Test
+
+```bash
+curl -u drs-user:drs-pass http://localhost:8080/healthz
+```
+
+## Local Auth
+
+For now, the documented local path is `auth.basic.username` plus `auth.basic.password`.
+
+## Notes
+
+- `auth.mode: gen3` is not the normal local path because it requires PostgreSQL unless you are explicitly using mock auth for integration testing.
+- If your bucket credentials are non-empty, Syfon still needs valid credential encryption at runtime. `credential_encryption.local_key_file` is the simplest local option.

--- a/docs/tools/syfon/quickstart.md
+++ b/docs/tools/syfon/quickstart.md
@@ -1,0 +1,60 @@
+# Quick Start
+
+This is the fastest way to get a local Syfon server running.
+
+For the raw config schema, see [Server Configuration](configuration.md). For a fuller local setup, see [Local Deployment](local-deployment.md).
+
+## Prerequisites
+
+- Go 1.24+
+- SQLite3 (`sqlite3`)
+- Git
+
+## 1. Clone and enter the repo
+
+```bash
+git clone <your-repo-url>
+cd syfon
+```
+
+## 2. Create a minimal local config
+
+```yaml
+port: 8080
+
+auth:
+  mode: local
+  basic:
+    username: drs-user
+    password: drs-pass
+
+database:
+  sqlite:
+    file: ./drs_local.db
+
+buckets:
+  - bucket: local-bucket
+    provider: s3
+    region: us-east-1
+    endpoint: http://localhost:9000
+    access_key: minio-user
+    secret_key: minio-pass
+```
+
+## 3. Start the server
+
+```bash
+go run . serve --config config.local.yaml
+```
+
+## 4. Smoke test
+
+```bash
+curl -u drs-user:drs-pass http://localhost:8080/healthz
+```
+
+## What To Read Next
+
+- [Local Deployment](local-deployment.md) for a practical SQLite plus local-auth setup
+- [Kubernetes Deployment](kubernetes-deployment.md) for the Helm chart
+- [Server Configuration](configuration.md) when you need field-by-field config details

--- a/docs/tools/syfon/troubleshooting.md
+++ b/docs/tools/syfon/troubleshooting.md
@@ -1,0 +1,175 @@
+# Troubleshooting
+
+This page is for operators running Syfon, not for development workflow issues.
+
+## Server Will Not Start
+
+### `no database specified in config`
+
+Syfon requires exactly one database backend.
+
+Use one of:
+
+- `database.sqlite.file` for local deployments
+- `database.postgres.*` for Gen3 and normal Kubernetes deployments
+
+### `multiple databases specified in config`
+
+You configured both `database.sqlite` and `database.postgres`.
+
+Remove one of them. Local deployments should normally keep SQLite. Gen3 and Helm-based deployments should normally keep PostgreSQL.
+
+### `auth.mode is required` or `invalid auth.mode`
+
+Set `auth.mode` to exactly one of:
+
+- `local`
+- `gen3`
+
+### `auth.mode "gen3" requires postgres database`
+
+`gen3` mode requires PostgreSQL in normal operation.
+
+Fix:
+
+- use PostgreSQL for Gen3 deployments
+- or switch the deployment to `auth.mode: local` if this is a local operator setup
+
+### `auth.mode "local" requires auth.basic.username/password`
+
+The documented local path requires Basic Auth unless you explicitly set:
+
+```yaml
+auth:
+  allow_unauthenticated: true
+```
+
+That bypass is for development only.
+
+## Storage Configuration Problems
+
+### `bucket credential not found`
+
+Syfon could not find a configured bucket entry that matches the requested bucket.
+
+Check:
+
+- the `bucket` name in `buckets`
+- whether you intended to use `buckets` or legacy `s3_credentials`
+- whether the client is targeting the same bucket name you configured
+
+### Upload URL is generated but upload fails
+
+This usually means Syfon was able to sign the request, but the client could not reach the storage endpoint.
+
+Check:
+
+- `endpoint` is correct
+- `http` vs `https` matches the object store
+- the object store is reachable from the client network
+- the bucket credentials are valid for that bucket
+
+### Presigned upload or download points at the wrong path
+
+Check your bucket routing rules:
+
+- `resources` if you want organization/project-derived mappings
+- `bucket_scopes` if you want exact explicit mappings
+
+If you are using the Helm chart, prefer `config.buckets` and keep the routing rules inside that block.
+
+## Credential Encryption Problems
+
+### `encrypted credential found but master key is not configured`
+
+Syfon found encrypted bucket credentials, but it cannot load the KEK required to decrypt them.
+
+Check:
+
+- `DRS_CREDENTIAL_LOCAL_KEY_FILE` points at the expected KEK file
+- or `credential_encryption.local_key_file` points at the expected KEK file
+- or `DRS_CREDENTIAL_MASTER_KEY` is set to the expected key material
+
+### Bucket credentials worked before but fail after restart
+
+This usually means the KEK changed or the KEK file was not persisted.
+
+For local deployments:
+
+- persist the KEK file alongside the SQLite DB
+- do not rotate or replace it unless you are also re-encrypting stored credentials
+
+## Authentication Problems
+
+### `401 Unauthorized` in local mode
+
+Check the Basic Auth credentials you configured in:
+
+- `auth.basic.username`
+- `auth.basic.password`
+
+If you are using a reverse proxy, also confirm it is forwarding the `Authorization` header.
+
+### `401` or `403` for every request in `gen3` mode
+
+Check:
+
+- `auth.fence_url` points at the correct public Fence endpoint
+- PostgreSQL is configured and reachable
+- the incoming token is actually being forwarded to Syfon
+
+For local integration testing only, you can use Gen3 mock auth. That is a test path, not the normal operator path.
+
+## Database Problems
+
+### SQLite: `database is locked`
+
+SQLite is appropriate for a single local Syfon instance, not a multi-replica deployment.
+
+Fix:
+
+- run a single local server process
+- avoid sharing one SQLite file across multiple writers
+- use PostgreSQL for multi-instance deployments
+
+### PostgreSQL connection failures
+
+Check:
+
+- `DRS_DB_HOST`
+- `DRS_DB_PORT`
+- `DRS_DB_USER`
+- `DRS_DB_PASSWORD`
+- `DRS_DB_DATABASE`
+- `DRS_DB_SSLMODE`
+
+If you are using the Helm chart, those are injected from the app DB secret. Verify the secret contents first.
+
+## Kubernetes Problems
+
+### Pod starts but Syfon immediately exits
+
+Check:
+
+- the rendered config Secret mounted at `/etc/drs/config.yaml`
+- the app DB secret providing `DRS_DB_*`
+- whether `config.auth.mode` and the chosen database backend are compatible
+
+### Init job fails
+
+The chart's PostgreSQL init job creates the app role, creates the app database, and applies the schema.
+
+Check:
+
+- admin DB credentials
+- app DB credentials
+- PostgreSQL network reachability
+- whether you intended to disable `postgres.initJob.enabled`
+
+## Docs Problems
+
+### A docs page does not match the real chart
+
+For Kubernetes behavior, treat the chart as the source of truth:
+
+- [gen3-helm `helm/syfon`](https://github.com/calypr/gen3-helm/tree/ohsu-develop/helm/syfon)


### PR DESCRIPTION
# Overview 🌀

This PR resolves 404 errors for git-drs and syfon documentation pages, missing static assets, and broken Funnel download links.

## Root Cause 🔍

Two commits combined to produce the 404s:

1. Commit [e9da1b5](https://github.com/calypr/calypr.github.io/commit/e9da1b5) ("full convert over to zensical") set `docs_dir = ".generated/docs"` in `zensical.toml`, so Zensical read all docs from `.generated/docs/` — a directory that is gitignored and only exists after a local build.

2. Commit [735db94](http://github.com/calypr/calypr.github.io/commit/735db94) ("fix: Setup commands") removed `docs_dir = ".generated/docs"` and added a `[plugins.multirepo]` block as the intended replacement. However, Zensical does not yet implement multirepo plugin functionality ([zensical/backlog#26](https://github.com/zensical/backlog/issues/26)), so the build silently produced no content for git-drs or syfon. With no pages to resolve, MkDocs emitted raw `.md` hrefs in the nav instead of proper `/tool/page/` URLs, causing 404s on every affected page.

## Current Behavior ⚠️

- `https://calypr.org/tools/git-drs/installation/` → 404
- `https://calypr.org/tools/syfon/` → 404
- All git-drs and syfon nav links rendered as raw `.md` hrefs
- `termynal.css` / `termynal.js` missing from built site
- Funnel download table pointed to `ohsu-comp-bio/funnel@v0.11.7` (release does not exist)

## New Behavior ✔️

- All git-drs and syfon pages resolve correctly
- `termynal.css` / `termynal.js` present in built site
- Funnel download table points to `calypr/funnel@v0.11.12`
- Lychee: 2,490 errors → 20 (remaining are external URLs not yet live on `calypr.org`, plus `calypr-public.ohsu.edu` which is a live infrastructure issue)

## Fix

Copied the missing doc files from `.generated/docs/` into the committed `docs/` tree so they are present for CI builds:

- `docs/tools/git-drs/` — added `commands.md`, `getting-started.md`, `installation.md`, `quickstart.md`, `troubleshooting.md`, and 5 files under `docs/`
- `docs/tools/syfon/` — added `index.md`, `quickstart.md`, `local-deployment.md`, `kubernetes-deployment.md`, `configuration.md`, `encryption.md`, `troubleshooting.md`, `deployment.md`
- `docs/termynal.css` and `docs/termynal.js` — copied from `.generated/docs/`
- `docs/tools/funnel/docs/_releases.md` — updated repo and version

This is a workaround until [zensical/backlog#26](https://github.com/zensical/backlog/issues/26) is resolved, at which point the committed copies can be removed and the build will fetch them automatically.